### PR TITLE
Add maintenance schedule pages

### DIFF
--- a/ProjectTracker.Admin/Pages/Shared/_Layout.cshtml
+++ b/ProjectTracker.Admin/Pages/Shared/_Layout.cshtml
@@ -32,7 +32,7 @@
                                 <a class="nav-link text-dark" asp-area="" asp-page="/Projects/Index">Projects</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link text-dark" asp-area="" asp-page="/Tasks/Index">Tasks</a>
+                                <a class="nav-link text-dark" asp-area="" asp-page="/Tasks/Index">Maintenance</a>
                             </li>
                         }
                     </ul>

--- a/ProjectTracker.Admin/Pages/Tasks/Create.cshtml
+++ b/ProjectTracker.Admin/Pages/Tasks/Create.cshtml
@@ -1,0 +1,58 @@
+@page
+@model ProjectTracker.Admin.Pages.Tasks.CreateModel
+@{
+    ViewData["Title"] = "Create Schedule";
+}
+
+<h1>Create Maintenance Schedule</h1>
+
+<hr />
+<div class="row">
+    <div class="col-md-6">
+        <form method="post">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div class="form-group">
+                <label asp-for="Schedule.EquipmentId" class="control-label"></label>
+                <select asp-for="Schedule.EquipmentId" asp-items="Model.EquipmentList" class="form-control"></select>
+                <span asp-validation-for="Schedule.EquipmentId" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Schedule.MaintenanceType" class="control-label"></label>
+                <input asp-for="Schedule.MaintenanceType" class="form-control" />
+                <span asp-validation-for="Schedule.MaintenanceType" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Schedule.IntervalDays" class="control-label"></label>
+                <input asp-for="Schedule.IntervalDays" class="form-control" />
+                <span asp-validation-for="Schedule.IntervalDays" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Schedule.LastMaintenanceDate" class="control-label"></label>
+                <input asp-for="Schedule.LastMaintenanceDate" type="date" class="form-control" />
+                <span asp-validation-for="Schedule.LastMaintenanceDate" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Schedule.NextMaintenanceDate" class="control-label"></label>
+                <input asp-for="Schedule.NextMaintenanceDate" type="date" class="form-control" />
+                <span asp-validation-for="Schedule.NextMaintenanceDate" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Schedule.Instructions" class="control-label"></label>
+                <textarea asp-for="Schedule.Instructions" class="form-control"></textarea>
+                <span asp-validation-for="Schedule.Instructions" class="text-danger"></span>
+            </div>
+            <div class="form-group form-check">
+                <input asp-for="Schedule.IsNotificationSent" class="form-check-input" />
+                <label asp-for="Schedule.IsNotificationSent" class="form-check-label"></label>
+            </div>
+            <div class="form-group mt-3">
+                <input type="submit" value="Create" class="btn btn-primary" />
+                <a asp-page="Index" class="btn btn-secondary">Back to List</a>
+            </div>
+        </form>
+    </div>
+</div>
+
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+}

--- a/ProjectTracker.Admin/Pages/Tasks/Create.cshtml.cs
+++ b/ProjectTracker.Admin/Pages/Tasks/Create.cshtml.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using ProjectTracker.Core.Entities;
+using ProjectTracker.Data.Context;
+using System;
+using System.Threading.Tasks;
+
+namespace ProjectTracker.Admin.Pages.Tasks
+{
+    public class CreateModel : PageModel
+    {
+        private readonly AppDbContext _context;
+
+        public CreateModel(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        [BindProperty]
+        public MaintenanceSchedule Schedule { get; set; } = default!;
+
+        public SelectList EquipmentList { get; set; } = default!;
+
+        public async Task<IActionResult> OnGetAsync()
+        {
+            EquipmentList = new SelectList(await _context.Equipments.ToListAsync(), "Id", "Name");
+            Schedule = new MaintenanceSchedule
+            {
+                LastMaintenanceDate = DateTime.Today,
+                NextMaintenanceDate = DateTime.Today
+            };
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                EquipmentList = new SelectList(await _context.Equipments.ToListAsync(), "Id", "Name", Schedule.EquipmentId);
+                return Page();
+            }
+
+            _context.MaintenanceSchedules.Add(Schedule);
+            await _context.SaveChangesAsync();
+
+            return RedirectToPage("Index");
+        }
+    }
+}

--- a/ProjectTracker.Admin/Pages/Tasks/Delete.cshtml
+++ b/ProjectTracker.Admin/Pages/Tasks/Delete.cshtml
@@ -1,0 +1,22 @@
+@page
+@model ProjectTracker.Admin.Pages.Tasks.DeleteModel
+@{
+    ViewData["Title"] = "Delete Schedule";
+}
+
+<h1>Delete Schedule</h1>
+
+<h3>Are you sure you want to delete this?</h3>
+<div>
+    <h4>@Model.Schedule.Equipment?.Name - @Model.Schedule.MaintenanceType</h4>
+    <dl class="row">
+        <dt class="col-sm-3">Next Maintenance</dt>
+        <dd class="col-sm-9">@Model.Schedule.NextMaintenanceDate.ToShortDateString()</dd>
+    </dl>
+
+    <form method="post">
+        <input type="hidden" asp-for="Schedule.Id" />
+        <input type="submit" value="Delete" class="btn btn-danger" />
+        <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+    </form>
+</div>

--- a/ProjectTracker.Admin/Pages/Tasks/Delete.cshtml.cs
+++ b/ProjectTracker.Admin/Pages/Tasks/Delete.cshtml.cs
@@ -1,0 +1,58 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectTracker.Core.Entities;
+using ProjectTracker.Data.Context;
+using System.Threading.Tasks;
+
+namespace ProjectTracker.Admin.Pages.Tasks
+{
+    public class DeleteModel : PageModel
+    {
+        private readonly AppDbContext _context;
+
+        public DeleteModel(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        [BindProperty]
+        public MaintenanceSchedule Schedule { get; set; } = default!;
+
+        public async Task<IActionResult> OnGetAsync(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            Schedule = await _context.MaintenanceSchedules
+                .Include(m => m.Equipment)
+                .FirstOrDefaultAsync(m => m.Id == id);
+
+            if (Schedule == null)
+            {
+                return NotFound();
+            }
+
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var schedule = await _context.MaintenanceSchedules.FindAsync(id);
+            if (schedule != null)
+            {
+                _context.MaintenanceSchedules.Remove(schedule);
+                await _context.SaveChangesAsync();
+            }
+
+            return RedirectToPage("Index");
+        }
+    }
+}

--- a/ProjectTracker.Admin/Pages/Tasks/Details.cshtml
+++ b/ProjectTracker.Admin/Pages/Tasks/Details.cshtml
@@ -1,0 +1,28 @@
+@page
+@model ProjectTracker.Admin.Pages.Tasks.DetailsModel
+@{
+    ViewData["Title"] = "Schedule Details";
+}
+
+<h1>Schedule Details</h1>
+
+<div>
+    <h4>Maintenance Schedule</h4>
+    <hr />
+    <dl class="row">
+        <dt class="col-sm-3">Equipment</dt>
+        <dd class="col-sm-9">@Model.Schedule.Equipment?.Name</dd>
+        <dt class="col-sm-3">Maintenance Type</dt>
+        <dd class="col-sm-9">@Model.Schedule.MaintenanceType</dd>
+        <dt class="col-sm-3">Interval Days</dt>
+        <dd class="col-sm-9">@Model.Schedule.IntervalDays</dd>
+        <dt class="col-sm-3">Last Maintenance</dt>
+        <dd class="col-sm-9">@Model.Schedule.LastMaintenanceDate.ToShortDateString()</dd>
+        <dt class="col-sm-3">Next Maintenance</dt>
+        <dd class="col-sm-9">@Model.Schedule.NextMaintenanceDate.ToShortDateString()</dd>
+        <dt class="col-sm-3">Instructions</dt>
+        <dd class="col-sm-9">@Model.Schedule.Instructions</dd>
+    </dl>
+    <a asp-page="Edit" asp-route-id="@Model.Schedule.Id" class="btn btn-primary">Edit</a>
+    <a asp-page="Index" class="btn btn-secondary">Back to List</a>
+</div>

--- a/ProjectTracker.Admin/Pages/Tasks/Details.cshtml.cs
+++ b/ProjectTracker.Admin/Pages/Tasks/Details.cshtml.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectTracker.Core.Entities;
+using ProjectTracker.Data.Context;
+using System.Threading.Tasks;
+
+namespace ProjectTracker.Admin.Pages.Tasks
+{
+    public class DetailsModel : PageModel
+    {
+        private readonly AppDbContext _context;
+
+        public DetailsModel(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        public MaintenanceSchedule Schedule { get; set; } = default!;
+
+        public async Task<IActionResult> OnGetAsync(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            Schedule = await _context.MaintenanceSchedules
+                .Include(m => m.Equipment)
+                .FirstOrDefaultAsync(m => m.Id == id);
+
+            if (Schedule == null)
+            {
+                return NotFound();
+            }
+
+            return Page();
+        }
+    }
+}

--- a/ProjectTracker.Admin/Pages/Tasks/Edit.cshtml
+++ b/ProjectTracker.Admin/Pages/Tasks/Edit.cshtml
@@ -1,0 +1,59 @@
+@page
+@model ProjectTracker.Admin.Pages.Tasks.EditModel
+@{
+    ViewData["Title"] = "Edit Schedule";
+}
+
+<h1>Edit Maintenance Schedule</h1>
+
+<hr />
+<div class="row">
+    <div class="col-md-6">
+        <form method="post">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <input type="hidden" asp-for="Schedule.Id" />
+            <div class="form-group">
+                <label asp-for="Schedule.EquipmentId" class="control-label"></label>
+                <select asp-for="Schedule.EquipmentId" asp-items="Model.EquipmentList" class="form-control"></select>
+                <span asp-validation-for="Schedule.EquipmentId" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Schedule.MaintenanceType" class="control-label"></label>
+                <input asp-for="Schedule.MaintenanceType" class="form-control" />
+                <span asp-validation-for="Schedule.MaintenanceType" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Schedule.IntervalDays" class="control-label"></label>
+                <input asp-for="Schedule.IntervalDays" class="form-control" />
+                <span asp-validation-for="Schedule.IntervalDays" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Schedule.LastMaintenanceDate" class="control-label"></label>
+                <input asp-for="Schedule.LastMaintenanceDate" type="date" class="form-control" />
+                <span asp-validation-for="Schedule.LastMaintenanceDate" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Schedule.NextMaintenanceDate" class="control-label"></label>
+                <input asp-for="Schedule.NextMaintenanceDate" type="date" class="form-control" />
+                <span asp-validation-for="Schedule.NextMaintenanceDate" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Schedule.Instructions" class="control-label"></label>
+                <textarea asp-for="Schedule.Instructions" class="form-control"></textarea>
+                <span asp-validation-for="Schedule.Instructions" class="text-danger"></span>
+            </div>
+            <div class="form-group form-check">
+                <input asp-for="Schedule.IsNotificationSent" class="form-check-input" />
+                <label asp-for="Schedule.IsNotificationSent" class="form-check-label"></label>
+            </div>
+            <div class="form-group mt-3">
+                <input type="submit" value="Save" class="btn btn-primary" />
+                <a asp-page="Index" class="btn btn-secondary">Back to List</a>
+            </div>
+        </form>
+    </div>
+</div>
+
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+}

--- a/ProjectTracker.Admin/Pages/Tasks/Edit.cshtml.cs
+++ b/ProjectTracker.Admin/Pages/Tasks/Edit.cshtml.cs
@@ -1,0 +1,78 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using ProjectTracker.Core.Entities;
+using ProjectTracker.Data.Context;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ProjectTracker.Admin.Pages.Tasks
+{
+    public class EditModel : PageModel
+    {
+        private readonly AppDbContext _context;
+
+        public EditModel(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        [BindProperty]
+        public MaintenanceSchedule Schedule { get; set; } = default!;
+
+        public SelectList EquipmentList { get; set; } = default!;
+
+        public async Task<IActionResult> OnGetAsync(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            Schedule = await _context.MaintenanceSchedules.FirstOrDefaultAsync(m => m.Id == id);
+
+            if (Schedule == null)
+            {
+                return NotFound();
+            }
+
+            EquipmentList = new SelectList(await _context.Equipments.ToListAsync(), "Id", "Name", Schedule.EquipmentId);
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                EquipmentList = new SelectList(await _context.Equipments.ToListAsync(), "Id", "Name", Schedule.EquipmentId);
+                return Page();
+            }
+
+            _context.Attach(Schedule).State = EntityState.Modified;
+
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!ScheduleExists(Schedule.Id))
+                {
+                    return NotFound();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            return RedirectToPage("Index");
+        }
+
+        private bool ScheduleExists(int id)
+        {
+            return _context.MaintenanceSchedules.Any(e => e.Id == id);
+        }
+    }
+}

--- a/ProjectTracker.Admin/Pages/Tasks/Index.cshtml
+++ b/ProjectTracker.Admin/Pages/Tasks/Index.cshtml
@@ -1,0 +1,41 @@
+@page
+@model ProjectTracker.Admin.Pages.Tasks.IndexModel
+@{
+    ViewData["Title"] = "Maintenance Schedules";
+}
+
+<h1>Maintenance Schedules</h1>
+
+<p>
+    <a asp-page="Create" class="btn btn-primary">Create New Schedule</a>
+</p>
+
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>Equipment</th>
+            <th>Type</th>
+            <th>Interval (Days)</th>
+            <th>Last</th>
+            <th>Next</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var item in Model.Schedules)
+{
+        <tr>
+            <td>@item.Equipment?.Name</td>
+            <td>@item.MaintenanceType</td>
+            <td>@item.IntervalDays</td>
+            <td>@item.LastMaintenanceDate.ToShortDateString()</td>
+            <td>@item.NextMaintenanceDate.ToShortDateString()</td>
+            <td>
+                <a asp-page="Edit" asp-route-id="@item.Id" class="btn btn-sm btn-warning">Edit</a>
+                <a asp-page="Details" asp-route-id="@item.Id" class="btn btn-sm btn-info">Details</a>
+                <a asp-page="Delete" asp-route-id="@item.Id" class="btn btn-sm btn-danger">Delete</a>
+            </td>
+        </tr>
+}
+    </tbody>
+</table>

--- a/ProjectTracker.Admin/Pages/Tasks/Index.cshtml.cs
+++ b/ProjectTracker.Admin/Pages/Tasks/Index.cshtml.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectTracker.Core.Entities;
+using ProjectTracker.Data.Context;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ProjectTracker.Admin.Pages.Tasks
+{
+    public class IndexModel : PageModel
+    {
+        private readonly AppDbContext _context;
+
+        public IndexModel(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        public IList<MaintenanceSchedule> Schedules { get; set; } = default!;
+
+        public async Task OnGetAsync()
+        {
+            Schedules = await _context.MaintenanceSchedules
+                .Include(m => m.Equipment)
+                .ToListAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new Razor Pages under `Pages/Tasks` to manage `MaintenanceSchedule` entities
- populate equipment select lists when creating or editing
- link to the new section in the admin layout

## Testing
- `dotnet format ProjectTracker.sln` *(fails: command not found)*
- `dotnet build ProjectTracker.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889bca88f78832b931706147dc33306