### PR TITLE
Add maintenance schedule service

### DIFF
--- a/ProjectTracker.Admin/Program.cs
+++ b/ProjectTracker.Admin/Program.cs
@@ -4,6 +4,10 @@ using Microsoft.AspNetCore.Authorization;
 using ProjectTracker.Core.Entities;
 using ProjectTracker.Data.Context;
 using ProjectTracker.Data.Seed;
+using ProjectTracker.Data.Repositories;
+using ProjectTracker.Service.Services.Implementations;
+using ProjectTracker.Service.Services.Interfaces;
+using ProjectTracker.Service.Mapping;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -36,6 +40,9 @@ builder.Services.AddRazorPages(opt =>
     opt.Conventions.AuthorizeFolder("/", "AdminOnly");
     opt.Conventions.AllowAnonymousToAreaFolder("Identity", "/Account");
 });
+builder.Services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
+builder.Services.AddAutoMapper(typeof(MappingProfile));
+builder.Services.AddScoped<IMaintenanceScheduleService, MaintenanceScheduleService>();
 
 // ------------------------------------------------------------------
 // Adapter services so the stock Identity UI (which asks for

--- a/ProjectTracker.Admin/ProjectTracker.Admin.csproj
+++ b/ProjectTracker.Admin/ProjectTracker.Admin.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ProjectTracker.Core\ProjectTracker.Core.csproj" />
     <ProjectReference Include="..\ProjectTracker.Data\ProjectTracker.Data.csproj" />
+    <ProjectReference Include="..\ProjectTracker.Service\ProjectTracker.Service.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ProjectTracker.Service/Services/Implementations/MaintenanceScheduleService.cs
+++ b/ProjectTracker.Service/Services/Implementations/MaintenanceScheduleService.cs
@@ -1,0 +1,90 @@
+using AutoMapper;
+using ProjectTracker.Core.Entities;
+using ProjectTracker.Data.Repositories;
+using ProjectTracker.Service.DTOs;
+using ProjectTracker.Service.Services.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+namespace ProjectTracker.Service.Services.Implementations
+{
+    public class MaintenanceScheduleService : IMaintenanceScheduleService
+    {
+        private readonly IRepository<MaintenanceSchedule> _scheduleRepository;
+        private readonly IMapper _mapper;
+
+        public MaintenanceScheduleService(
+            IRepository<MaintenanceSchedule> scheduleRepository,
+            IMapper mapper)
+        {
+            _scheduleRepository = scheduleRepository;
+            _mapper = mapper;
+        }
+
+        public async Task<IEnumerable<MaintenanceScheduleDto>> GetAllSchedulesAsync()
+        {
+            var schedules = await _scheduleRepository.GetAsync(
+                includes: new Expression<Func<MaintenanceSchedule, object>>[]
+                {
+                    s => s.Equipment
+                });
+            return _mapper.Map<IEnumerable<MaintenanceScheduleDto>>(schedules);
+        }
+
+        public async Task<MaintenanceScheduleDto> GetScheduleByIdAsync(int id)
+        {
+            var schedules = await _scheduleRepository.GetAsync(
+                s => s.Id == id,
+                includes: new Expression<Func<MaintenanceSchedule, object>>[]
+                {
+                    s => s.Equipment
+                });
+            var schedule = schedules.FirstOrDefault();
+            return _mapper.Map<MaintenanceScheduleDto>(schedule);
+        }
+
+        public async Task<MaintenanceScheduleDto> CreateScheduleAsync(MaintenanceScheduleDto scheduleDto)
+        {
+            var schedule = _mapper.Map<MaintenanceSchedule>(scheduleDto);
+            await _scheduleRepository.AddAsync(schedule);
+            return _mapper.Map<MaintenanceScheduleDto>(schedule);
+        }
+
+        public async Task<MaintenanceScheduleDto> UpdateScheduleAsync(int id, MaintenanceScheduleDto scheduleDto)
+        {
+            var schedule = await _scheduleRepository.GetByIdAsync(id);
+            if (schedule == null)
+                return null;
+
+            _mapper.Map(scheduleDto, schedule);
+            await _scheduleRepository.UpdateAsync(schedule);
+            return _mapper.Map<MaintenanceScheduleDto>(schedule);
+        }
+
+        public async Task<bool> DeleteScheduleAsync(int id)
+        {
+            var schedule = await _scheduleRepository.GetByIdAsync(id);
+            if (schedule == null)
+                return false;
+
+            await _scheduleRepository.DeleteAsync(schedule);
+            return true;
+        }
+
+        public async Task<IEnumerable<MaintenanceScheduleDto>> GetUpcomingSchedulesAsync(int daysAhead)
+        {
+            DateTime targetDate = DateTime.UtcNow.Date.AddDays(daysAhead);
+            var schedules = await _scheduleRepository.GetAsync(
+                s => s.NextMaintenanceDate <= targetDate && s.NextMaintenanceDate >= DateTime.UtcNow.Date,
+                orderBy: q => q.OrderBy(s => s.NextMaintenanceDate),
+                includes: new Expression<Func<MaintenanceSchedule, object>>[]
+                {
+                    s => s.Equipment
+                });
+            return _mapper.Map<IEnumerable<MaintenanceScheduleDto>>(schedules);
+        }
+    }
+}

--- a/ProjectTracker.Service/Services/Interfaces/IMaintenanceScheduleService.cs
+++ b/ProjectTracker.Service/Services/Interfaces/IMaintenanceScheduleService.cs
@@ -1,0 +1,16 @@
+using ProjectTracker.Service.DTOs;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ProjectTracker.Service.Services.Interfaces
+{
+    public interface IMaintenanceScheduleService
+    {
+        Task<IEnumerable<MaintenanceScheduleDto>> GetAllSchedulesAsync();
+        Task<MaintenanceScheduleDto> GetScheduleByIdAsync(int id);
+        Task<MaintenanceScheduleDto> CreateScheduleAsync(MaintenanceScheduleDto scheduleDto);
+        Task<MaintenanceScheduleDto> UpdateScheduleAsync(int id, MaintenanceScheduleDto scheduleDto);
+        Task<bool> DeleteScheduleAsync(int id);
+        Task<IEnumerable<MaintenanceScheduleDto>> GetUpcomingSchedulesAsync(int daysAhead);
+    }
+}

--- a/ProjectTracker.Web/Program.cs
+++ b/ProjectTracker.Web/Program.cs
@@ -1,5 +1,5 @@
 using MediatR;
-using ProjectTracker.Core.Events; // Event'in bulunduðu assembly  
+using ProjectTracker.Core.Events; // Event'in bulunduÃ°u assembly  
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Identity;
@@ -95,6 +95,7 @@ builder.Services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
 builder.Services.AddScoped<IProjectService, ProjectService>();
 builder.Services.AddScoped<IWorkLogService, WorkLogService>();
 builder.Services.AddScoped<IEmployeeService, EmployeeService>();
+builder.Services.AddScoped<IMaintenanceScheduleService, MaintenanceScheduleService>();
 
 // Authorization Configuration
 builder.Services.AddAuthorization(options =>


### PR DESCRIPTION
## Summary
- add IMaintenanceScheduleService interface
- implement MaintenanceScheduleService
- register MaintenanceScheduleService in Web and Admin apps
- reference service project from Admin project

## Testing
- `dotnet build ProjectTracker.sln` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6889bcb10b80832b9c4ae4c7e77b3b6a