### PR TITLE
Add email sender interface and stub implementation

### DIFF
--- a/ProjectTracker.Service/Services/Implementations/EmailSender.cs
+++ b/ProjectTracker.Service/Services/Implementations/EmailSender.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.Extensions.Logging;
+
+namespace ProjectTracker.Service.Services.Implementations
+{
+    public class EmailSender : IEmailSender
+    {
+        private readonly ILogger<EmailSender> _logger;
+
+        public EmailSender(ILogger<EmailSender> logger)
+        {
+            _logger = logger;
+        }
+
+        public Task SendEmailAsync(string email, string subject, string htmlMessage)
+        {
+            _logger.LogInformation("Sending email to {Email} with subject {Subject}", email, subject);
+            // TODO: Implement actual email sending logic
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/ProjectTracker.Service/Services/Interfaces/IEmailSender.cs
+++ b/ProjectTracker.Service/Services/Interfaces/IEmailSender.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Identity.UI.Services
+{
+    public interface IEmailSender
+    {
+        Task SendEmailAsync(string email, string subject, string htmlMessage);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a local `IEmailSender` interface
- add a stub `EmailSender` class which logs messages

Builds could not be run because the `dotnet` CLI is unavailable in the environment.


------
https://chatgpt.com/codex/tasks/task_e_6889cbb1d3fc832b8d9effa398838ece