### PR TITLE
Fix AutoMapper registration and remove duplicate interface

### DIFF
--- a/ProjectTracker.Admin/ProjectTracker.Admin.csproj
+++ b/ProjectTracker.Admin/ProjectTracker.Admin.csproj
@@ -18,6 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
   </ItemGroup>
 

--- a/ProjectTracker.Service/Services/Interfaces/IEmailSender.cs
+++ b/ProjectTracker.Service/Services/Interfaces/IEmailSender.cs
@@ -1,9 +1,0 @@
-using System.Threading.Tasks;
-
-namespace Microsoft.AspNetCore.Identity.UI.Services
-{
-    public interface IEmailSender
-    {
-        Task SendEmailAsync(string email, string subject, string htmlMessage);
-    }
-}


### PR DESCRIPTION
## Summary
- reference AutoMapper.Extensions.Microsoft.DependencyInjection in Admin project
- remove duplicate IEmailSender interface that conflicted with Microsoft.Identity

## Testing
- `dotnet build ProjectTracker.sln -v q`

------
https://chatgpt.com/codex/tasks/task_e_6889d08c8fe4832b942b02d1cd17baae