### PR TITLE
Fix missing IEmailSender registration

### DIFF
--- a/ProjectTracker.Admin/Program.cs
+++ b/ProjectTracker.Admin/Program.cs
@@ -6,6 +6,7 @@ using ProjectTracker.Data.Context;
 using ProjectTracker.Data.Seed;
 
 using ProjectTracker.Service.Services.Implementations;
+using Microsoft.AspNetCore.Identity.UI.Services;
 
 using ProjectTracker.Data.Repositories;
 using ProjectTracker.Service.Services.Implementations;
@@ -46,6 +47,7 @@ builder.Services.AddRazorPages(opt =>
 });
 builder.Services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
 builder.Services.AddAutoMapper(typeof(MappingProfile));
+builder.Services.AddTransient<IEmailSender, EmailSender>();
 builder.Services.AddScoped<IMaintenanceScheduleService, MaintenanceScheduleService>();
 
 builder.Services.AddHostedService<MaintenanceNotificationService>();

--- a/ProjectTracker.Web/Program.cs
+++ b/ProjectTracker.Web/Program.cs
@@ -14,6 +14,7 @@ using ProjectTracker.Service.Mapping;
 using ProjectTracker.Service.Services.Implementations;
 using ProjectTracker.Service.Services.Interfaces;
 using ProjectTracker.Web.Authorization;
+using Microsoft.AspNetCore.Identity.UI.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -87,6 +88,9 @@ builder.Services.ConfigureApplicationCookie(options =>
 
 // AutoMapper
 builder.Services.AddAutoMapper(typeof(MappingProfile));
+
+// Email sender implementation
+builder.Services.AddTransient<IEmailSender, EmailSender>();
 
 // Repositories
 builder.Services.AddScoped(typeof(IRepository<>), typeof(Repository<>));


### PR DESCRIPTION
## Summary
- register `EmailSender` as the implementation for `IEmailSender`
- add the necessary using directives

## Testing
- `dotnet build ProjectTracker.sln`

------
https://chatgpt.com/codex/tasks/task_e_6889d306f650832bb4b6182f1096df46