### PR TITLE
Add maintenance tasks management

### DIFF
--- a/ProjectTracker.Admin/MaintenanceNotificationService.cs
+++ b/ProjectTracker.Admin/MaintenanceNotificationService.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Hosting;
+using ProjectTracker.Service.Services.Interfaces;
+
+namespace ProjectTracker.Admin
+{
+    public class MaintenanceNotificationService : BackgroundService
+    {
+        private readonly IServiceProvider _services;
+        private readonly ILogger<MaintenanceNotificationService> _logger;
+
+        public MaintenanceNotificationService(IServiceProvider services, ILogger<MaintenanceNotificationService> logger)
+        {
+            _services = services;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                using var scope = _services.CreateScope();
+                var service = scope.ServiceProvider.GetRequiredService<IMaintenanceScheduleService>();
+                var due = await service.GetDueAsync();
+                foreach (var item in due)
+                {
+                    _logger.LogInformation("Maintenance task due for equipment {Equipment} on {Date}", item.EquipmentName, item.NextMaintenanceDate);
+                    await service.MarkNotifiedAsync(item.Id);
+                }
+                await Task.Delay(TimeSpan.FromHours(1), stoppingToken);
+            }
+        }
+    }
+}

--- a/ProjectTracker.Admin/Pages/Tasks/Create.cshtml
+++ b/ProjectTracker.Admin/Pages/Tasks/Create.cshtml
@@ -1,0 +1,31 @@
+@page
+@model ProjectTracker.Admin.Pages.Tasks.CreateModel
+@{
+    ViewData["Title"] = "Add Task";
+}
+
+<h1>Add Maintenance Task</h1>
+
+<form method="post">
+    <div class="mb-3">
+        <label asp-for="Task.EquipmentId" class="form-label"></label>
+        <select asp-for="Task.EquipmentId" asp-items="Model.EquipmentOptions" class="form-select"></select>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Task.MaintenanceType" class="form-label"></label>
+        <input asp-for="Task.MaintenanceType" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="Task.IntervalDays" class="form-label"></label>
+        <input asp-for="Task.IntervalDays" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="Task.LastMaintenanceDate" class="form-label"></label>
+        <input asp-for="Task.LastMaintenanceDate" class="form-control" type="date" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="Task.Instructions" class="form-label"></label>
+        <textarea asp-for="Task.Instructions" class="form-control"></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+</form>

--- a/ProjectTracker.Admin/Pages/Tasks/Create.cshtml.cs
+++ b/ProjectTracker.Admin/Pages/Tasks/Create.cshtml.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using ProjectTracker.Data.Context;
+using ProjectTracker.Core.Entities;
+using AutoMapper;
+using ProjectTracker.Service.DTOs;
+
+namespace ProjectTracker.Admin.Pages.Tasks
+{
+    public class CreateModel : PageModel
+    {
+        private readonly AppDbContext _context;
+        private readonly IMapper _mapper;
+
+        public CreateModel(AppDbContext context, IMapper mapper)
+        {
+            _context = context;
+            _mapper = mapper;
+        }
+
+        [BindProperty]
+        public MaintenanceScheduleDto Task { get; set; } = new();
+        public SelectList EquipmentOptions { get; set; } = default!;
+
+        public async Task OnGetAsync()
+        {
+            var equipments = await _context.Equipments.ToListAsync();
+            EquipmentOptions = new SelectList(equipments, "Id", "Name");
+            Task.LastMaintenanceDate = DateTime.Today;
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                await OnGetAsync();
+                return Page();
+            }
+
+            var entity = _mapper.Map<MaintenanceSchedule>(Task);
+            entity.NextMaintenanceDate = Task.LastMaintenanceDate.AddDays(Task.IntervalDays);
+            _context.MaintenanceSchedules.Add(entity);
+            await _context.SaveChangesAsync();
+            return RedirectToPage("Index");
+        }
+    }
+}

--- a/ProjectTracker.Admin/Pages/Tasks/Index.cshtml
+++ b/ProjectTracker.Admin/Pages/Tasks/Index.cshtml
@@ -1,0 +1,29 @@
+@page
+@model ProjectTracker.Admin.Pages.Tasks.IndexModel
+@{
+    ViewData["Title"] = "Maintenance Tasks";
+}
+
+<h1>Maintenance Tasks</h1>
+<a asp-page="Create" class="btn btn-primary mb-3">Add Task</a>
+<table class="table">
+    <thead>
+        <tr>
+            <th>Equipment</th>
+            <th>Type</th>
+            <th>Next Date</th>
+            <th>Notified</th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach (var task in Model.Tasks)
+    {
+        <tr>
+            <td>@task.EquipmentName</td>
+            <td>@task.MaintenanceType</td>
+            <td>@task.NextMaintenanceDate.ToShortDateString()</td>
+            <td>@task.IsNotificationSent</td>
+        </tr>
+    }
+    </tbody>
+</table>

--- a/ProjectTracker.Admin/Pages/Tasks/Index.cshtml.cs
+++ b/ProjectTracker.Admin/Pages/Tasks/Index.cshtml.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectTracker.Data.Context;
+using ProjectTracker.Service.DTOs;
+using AutoMapper;
+
+namespace ProjectTracker.Admin.Pages.Tasks
+{
+    public class IndexModel : PageModel
+    {
+        private readonly AppDbContext _context;
+        private readonly IMapper _mapper;
+
+        public IndexModel(AppDbContext context, IMapper mapper)
+        {
+            _context = context;
+            _mapper = mapper;
+        }
+
+        public IList<MaintenanceScheduleDto> Tasks { get; set; } = new List<MaintenanceScheduleDto>();
+
+        public async Task OnGetAsync()
+        {
+            var schedules = await _context.MaintenanceSchedules
+                .Include(m => m.Equipment)
+                .ToListAsync();
+            Tasks = _mapper.Map<IList<MaintenanceScheduleDto>>(schedules);
+        }
+    }
+}

--- a/ProjectTracker.Admin/Program.cs
+++ b/ProjectTracker.Admin/Program.cs
@@ -4,6 +4,9 @@ using Microsoft.AspNetCore.Authorization;
 using ProjectTracker.Core.Entities;
 using ProjectTracker.Data.Context;
 using ProjectTracker.Data.Seed;
+using ProjectTracker.Service.Services.Interfaces;
+using ProjectTracker.Service.Services.Implementations;
+using ProjectTracker.Admin;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -36,6 +39,9 @@ builder.Services.AddRazorPages(opt =>
     opt.Conventions.AuthorizeFolder("/", "AdminOnly");
     opt.Conventions.AllowAnonymousToAreaFolder("Identity", "/Account");
 });
+
+builder.Services.AddScoped<IMaintenanceScheduleService, MaintenanceScheduleService>();
+builder.Services.AddHostedService<MaintenanceNotificationService>();
 
 // ------------------------------------------------------------------
 // Adapter services so the stock Identity UI (which asks for
@@ -79,6 +85,12 @@ else
 }
 
 await IdentitySeed.SeedAsync(app.Services);
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    db.Database.EnsureCreated();
+}
 
 app.UseHttpsRedirection();
 app.UseStaticFiles();

--- a/ProjectTracker.Service/Services/Implementations/MaintenanceScheduleService.cs
+++ b/ProjectTracker.Service/Services/Implementations/MaintenanceScheduleService.cs
@@ -1,0 +1,57 @@
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using ProjectTracker.Core.Entities;
+using ProjectTracker.Data.Context;
+using ProjectTracker.Service.DTOs;
+using ProjectTracker.Service.Services.Interfaces;
+
+namespace ProjectTracker.Service.Services.Implementations
+{
+    public class MaintenanceScheduleService : IMaintenanceScheduleService
+    {
+        private readonly AppDbContext _context;
+        private readonly IMapper _mapper;
+
+        public MaintenanceScheduleService(AppDbContext context, IMapper mapper)
+        {
+            _context = context;
+            _mapper = mapper;
+        }
+
+        public async Task<IEnumerable<MaintenanceScheduleDto>> GetAllAsync()
+        {
+            var items = await _context.MaintenanceSchedules
+                .Include(m => m.Equipment)
+                .ToListAsync();
+            return _mapper.Map<IEnumerable<MaintenanceScheduleDto>>(items);
+        }
+
+        public async Task<IEnumerable<MaintenanceScheduleDto>> GetDueAsync()
+        {
+            var now = DateTime.Today;
+            var items = await _context.MaintenanceSchedules
+                .Where(m => m.NextMaintenanceDate <= now && !m.IsNotificationSent)
+                .Include(m => m.Equipment)
+                .ToListAsync();
+            return _mapper.Map<IEnumerable<MaintenanceScheduleDto>>(items);
+        }
+
+        public async Task AddAsync(MaintenanceScheduleDto dto)
+        {
+            var entity = _mapper.Map<MaintenanceSchedule>(dto);
+            entity.NextMaintenanceDate = dto.LastMaintenanceDate.AddDays(dto.IntervalDays);
+            _context.MaintenanceSchedules.Add(entity);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task MarkNotifiedAsync(int id)
+        {
+            var entity = await _context.MaintenanceSchedules.FindAsync(id);
+            if (entity != null)
+            {
+                entity.IsNotificationSent = true;
+                await _context.SaveChangesAsync();
+            }
+        }
+    }
+}

--- a/ProjectTracker.Service/Services/Interfaces/IMaintenanceScheduleService.cs
+++ b/ProjectTracker.Service/Services/Interfaces/IMaintenanceScheduleService.cs
@@ -1,0 +1,12 @@
+using ProjectTracker.Service.DTOs;
+
+namespace ProjectTracker.Service.Services.Interfaces
+{
+    public interface IMaintenanceScheduleService
+    {
+        Task<IEnumerable<MaintenanceScheduleDto>> GetAllAsync();
+        Task<IEnumerable<MaintenanceScheduleDto>> GetDueAsync();
+        Task AddAsync(MaintenanceScheduleDto dto);
+        Task MarkNotifiedAsync(int id);
+    }
+}


### PR DESCRIPTION
## Summary
- create tasks Razor Pages to manage `MaintenanceSchedule` entries
- add maintenance schedule service implementation
- run a hosted service that logs when tasks are due
- register the services and ensure the DB is created

## Testing
- `dotnet build ProjectTracker.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889d91c2124832bae750422fd5138e8