### PR TITLE
Fix Admin project references and AutoMapper setup

### DIFF
--- a/ProjectTracker.Admin/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/ProjectTracker.Admin/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
-using ProjectTracker.Core.Entities;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/ProjectTracker.Admin/Areas/Identity/Pages/Account/Logout.cshtml.cs
+++ b/ProjectTracker.Admin/Areas/Identity/Pages/Account/Logout.cshtml.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
-using ProjectTracker.Core.Entities;
 using System;
 using System.Threading.Tasks;
 

--- a/ProjectTracker.Admin/Program.cs
+++ b/ProjectTracker.Admin/Program.cs
@@ -6,6 +6,7 @@ using ProjectTracker.Data.Context;
 using ProjectTracker.Data.Seed;
 using ProjectTracker.Service.Services.Interfaces;
 using ProjectTracker.Service.Services.Implementations;
+using ProjectTracker.Service.Mapping;
 using ProjectTracker.Admin;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -39,6 +40,7 @@ builder.Services.AddRazorPages(opt =>
     opt.Conventions.AuthorizeFolder("/", "AdminOnly");
     opt.Conventions.AllowAnonymousToAreaFolder("Identity", "/Account");
 });
+builder.Services.AddAutoMapper(typeof(MappingProfile));
 
 builder.Services.AddScoped<IMaintenanceScheduleService, MaintenanceScheduleService>();
 builder.Services.AddHostedService<MaintenanceNotificationService>();

--- a/ProjectTracker.Admin/ProjectTracker.Admin.csproj
+++ b/ProjectTracker.Admin/ProjectTracker.Admin.csproj
@@ -18,12 +18,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ProjectTracker.Core\ProjectTracker.Core.csproj" />
     <ProjectReference Include="..\ProjectTracker.Data\ProjectTracker.Data.csproj" />
+    <ProjectReference Include="..\ProjectTracker.Service\ProjectTracker.Service.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- reference Service project from ProjectTracker.Admin
- install AutoMapper DI package for Admin
- register AutoMapper in Admin `Program.cs`
- remove duplicate `using` statements in Identity pages

## Testing
- `apt-get update` *(fails: Invalid response from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6889e07538f4832b9b242ea553418d2f