### PR TITLE
Add role-based authorization to work logs

### DIFF
--- a/ProjectTracker.Web/Controllers/WorkLogController.cs
+++ b/ProjectTracker.Web/Controllers/WorkLogController.cs
@@ -29,6 +29,7 @@ namespace ProjectTracker.Web.Controllers
         }
 
         // GET: WorkLog
+        [Authorize(Roles = "Admin,Manager,Employee")]
         public async Task<IActionResult> Index(string sortOrder, string currentFilter, string searchString, int? pageNumber, int? pageSize)
         {
             // Sorting parameters
@@ -51,8 +52,25 @@ namespace ProjectTracker.Web.Controllers
 
             ViewData["CurrentFilter"] = searchString;
 
-            // Get all work logs
-            var workLogs = await _workLogService.GetAllWorkLogsAsync();
+            // Get work logs based on user role
+            IEnumerable<WorkLogDto> workLogs;
+            var userIdValue = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (User.IsInRole("Admin") || User.IsInRole("Manager"))
+            {
+                workLogs = await _workLogService.GetAllWorkLogsAsync();
+            }
+            else if (User.IsInRole("Employee"))
+            {
+                if (string.IsNullOrEmpty(userIdValue) || !int.TryParse(userIdValue, out int userId))
+                {
+                    return Unauthorized();
+                }
+                workLogs = await _workLogService.GetWorkLogsByUserIdAsync(userId);
+            }
+            else
+            {
+                return Forbid();
+            }
 
             // Apply search filter
             if (!string.IsNullOrEmpty(searchString))
@@ -105,6 +123,7 @@ namespace ProjectTracker.Web.Controllers
         }
 
         // GET: WorkLog/MyWorkLog
+        [Authorize(Roles = "Admin,Manager,Employee")]
         public async Task<IActionResult> MyWorkLog(string sortOrder, string currentFilter, string searchString, int? pageNumber, int? pageSize)
         {
             // Get current user's work logs
@@ -181,6 +200,7 @@ namespace ProjectTracker.Web.Controllers
 
 
         // GET: WorkLog/Details/5
+        [Authorize(Roles = "Admin,Manager,Employee")]
         public async Task<IActionResult> Details(int id)
         {
             var workLog = await _workLogService.GetWorkLogByIdAsync(id);
@@ -189,23 +209,70 @@ namespace ProjectTracker.Web.Controllers
                 return NotFound();
             }
 
+            if (!User.IsInRole("Admin") && !User.IsInRole("Manager"))
+            {
+                var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                if (string.IsNullOrEmpty(userIdClaim) || !int.TryParse(userIdClaim, out int userId))
+                {
+                    return Unauthorized();
+                }
+                var employee = await _employeeService.GetEmployeeByUserIdAsync(userId);
+                if (employee == null || workLog.EmployeeId != employee.Id)
+                {
+                    return Forbid();
+                }
+            }
+
             return View(workLog);
         }
 
         // GET: WorkLog/Create
+        [Authorize(Roles = "Admin,Manager,Employee")]
         public async Task<IActionResult> Create()
         {
             ViewData["ProjectId"] = new SelectList(await _projectService.GetAllProjectsAsync(), "Id", "Name");
-            ViewData["EmployeeId"] = new SelectList(await _employeeService.GetAllEmployeesAsync(), "Id", "FullName");
+            if (User.IsInRole("Employee"))
+            {
+                var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                if (string.IsNullOrEmpty(userIdClaim) || !int.TryParse(userIdClaim, out int userId))
+                {
+                    return Unauthorized();
+                }
+                var employee = await _employeeService.GetEmployeeByUserIdAsync(userId);
+                if (employee == null)
+                {
+                    return Forbid();
+                }
+                ViewData["EmployeeId"] = new SelectList(new[] { employee }, "Id", "FullName");
+            }
+            else
+            {
+                ViewData["EmployeeId"] = new SelectList(await _employeeService.GetAllEmployeesAsync(), "Id", "FullName");
+            }
 
             return View();
         }
 
         // POST: WorkLog/Create
+        [Authorize(Roles = "Admin,Manager,Employee")]
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create(WorkLogDto workLogDto)
         {
+            if (User.IsInRole("Employee"))
+            {
+                var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                if (string.IsNullOrEmpty(userIdClaim) || !int.TryParse(userIdClaim, out int userId))
+                {
+                    return Unauthorized();
+                }
+                var employee = await _employeeService.GetEmployeeByUserIdAsync(userId);
+                if (employee == null || workLogDto.EmployeeId != employee.Id)
+                {
+                    return Forbid();
+                }
+            }
+
             if (ModelState.IsValid)
             {
                 await _workLogService.CreateWorkLogAsync(workLogDto);
@@ -213,12 +280,25 @@ namespace ProjectTracker.Web.Controllers
             }
 
             ViewData["ProjectId"] = new SelectList(await _projectService.GetAllProjectsAsync(), "Id", "Name", workLogDto.ProjectId);
-            ViewData["EmployeeId"] = new SelectList(await _employeeService.GetAllEmployeesAsync(), "Id", "FullName", workLogDto.EmployeeId);
+            if (User.IsInRole("Employee"))
+            {
+                var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                if (!string.IsNullOrEmpty(userIdClaim) && int.TryParse(userIdClaim, out int userId))
+                {
+                    var employee = await _employeeService.GetEmployeeByUserIdAsync(userId);
+                    ViewData["EmployeeId"] = new SelectList(new[] { employee }, "Id", "FullName", workLogDto.EmployeeId);
+                }
+            }
+            else
+            {
+                ViewData["EmployeeId"] = new SelectList(await _employeeService.GetAllEmployeesAsync(), "Id", "FullName", workLogDto.EmployeeId);
+            }
 
             return View(workLogDto);
         }
 
         // GET: WorkLog/Edit/5
+        [Authorize(Roles = "Admin,Manager,Employee")]
         public async Task<IActionResult> Edit(int id)
         {
             var workLog = await _workLogService.GetWorkLogByIdAsync(id);
@@ -228,12 +308,30 @@ namespace ProjectTracker.Web.Controllers
             }
 
             ViewData["ProjectId"] = new SelectList(await _projectService.GetAllProjectsAsync(), "Id", "Name", workLog.ProjectId);
-            ViewData["EmployeeId"] = new SelectList(await _employeeService.GetAllEmployeesAsync(), "Id", "FullName", workLog.EmployeeId);
+            if (!User.IsInRole("Admin") && !User.IsInRole("Manager"))
+            {
+                var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                if (string.IsNullOrEmpty(userIdClaim) || !int.TryParse(userIdClaim, out int userId))
+                {
+                    return Unauthorized();
+                }
+                var employee = await _employeeService.GetEmployeeByUserIdAsync(userId);
+                if (employee == null || workLog.EmployeeId != employee.Id)
+                {
+                    return Forbid();
+                }
+                ViewData["EmployeeId"] = new SelectList(new[] { employee }, "Id", "FullName", workLog.EmployeeId);
+            }
+            else
+            {
+                ViewData["EmployeeId"] = new SelectList(await _employeeService.GetAllEmployeesAsync(), "Id", "FullName", workLog.EmployeeId);
+            }
 
             return View(workLog);
         }
 
         // POST: WorkLog/Edit/5
+        [Authorize(Roles = "Admin,Manager,Employee")]
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Edit(int id, WorkLogDto workLogDto)
@@ -243,6 +341,20 @@ namespace ProjectTracker.Web.Controllers
                 return NotFound();
             }
 
+            if (!User.IsInRole("Admin") && !User.IsInRole("Manager"))
+            {
+                var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                if (string.IsNullOrEmpty(userIdClaim) || !int.TryParse(userIdClaim, out int userId))
+                {
+                    return Unauthorized();
+                }
+                var employee = await _employeeService.GetEmployeeByUserIdAsync(userId);
+                if (employee == null || workLogDto.EmployeeId != employee.Id)
+                {
+                    return Forbid();
+                }
+            }
+
             if (ModelState.IsValid)
             {
                 await _workLogService.UpdateWorkLogAsync(id, workLogDto);
@@ -250,12 +362,25 @@ namespace ProjectTracker.Web.Controllers
             }
 
             ViewData["ProjectId"] = new SelectList(await _projectService.GetAllProjectsAsync(), "Id", "Name", workLogDto.ProjectId);
-            ViewData["EmployeeId"] = new SelectList(await _employeeService.GetAllEmployeesAsync(), "Id", "FullName", workLogDto.EmployeeId);
+            if (!User.IsInRole("Admin") && !User.IsInRole("Manager"))
+            {
+                var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                if (!string.IsNullOrEmpty(userIdClaim) && int.TryParse(userIdClaim, out int userId))
+                {
+                    var employee = await _employeeService.GetEmployeeByUserIdAsync(userId);
+                    ViewData["EmployeeId"] = new SelectList(new[] { employee }, "Id", "FullName", workLogDto.EmployeeId);
+                }
+            }
+            else
+            {
+                ViewData["EmployeeId"] = new SelectList(await _employeeService.GetAllEmployeesAsync(), "Id", "FullName", workLogDto.EmployeeId);
+            }
 
             return View(workLogDto);
         }
 
         // GET: WorkLog/Delete/5
+        [Authorize(Roles = "Admin,Manager,Employee")]
         public async Task<IActionResult> Delete(int id)
         {
             var workLog = await _workLogService.GetWorkLogByIdAsync(id);
@@ -264,20 +389,55 @@ namespace ProjectTracker.Web.Controllers
                 return NotFound();
             }
 
+            if (!User.IsInRole("Admin") && !User.IsInRole("Manager"))
+            {
+                var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                if (string.IsNullOrEmpty(userIdClaim) || !int.TryParse(userIdClaim, out int userId))
+                {
+                    return Unauthorized();
+                }
+                var employee = await _employeeService.GetEmployeeByUserIdAsync(userId);
+                if (employee == null || workLog.EmployeeId != employee.Id)
+                {
+                    return Forbid();
+                }
+            }
+
             return View(workLog);
         }
 
         // POST: WorkLog/Delete/5
+        [Authorize(Roles = "Admin,Manager,Employee")]
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> DeleteConfirmed(int id)
         {
+            var workLog = await _workLogService.GetWorkLogByIdAsync(id);
+            if (workLog == null)
+            {
+                return NotFound();
+            }
+
+            if (!User.IsInRole("Admin") && !User.IsInRole("Manager"))
+            {
+                var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                if (string.IsNullOrEmpty(userIdClaim) || !int.TryParse(userIdClaim, out int userId))
+                {
+                    return Unauthorized();
+                }
+                var employee = await _employeeService.GetEmployeeByUserIdAsync(userId);
+                if (employee == null || workLog.EmployeeId != employee.Id)
+                {
+                    return Forbid();
+                }
+            }
+
             await _workLogService.DeleteWorkLogAsync(id);
             return RedirectToAction(nameof(Index));
-
-
         }
-            public async Task<IActionResult> MyWorkLogs()
+
+        [Authorize(Roles = "Admin,Manager,Employee")]
+        public async Task<IActionResult> MyWorkLogs()
         {
             var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
             if (string.IsNullOrEmpty(userIdClaim) || !int.TryParse(userIdClaim, out int userId))
@@ -295,6 +455,6 @@ namespace ProjectTracker.Web.Controllers
 
             var workLogs = await _workLogService.GetWorkLogsByEmployeeIdAsync(employee.Id);
             return View(workLogs);
-            }
         }
     }
+}


### PR DESCRIPTION
## Summary
- restrict work log controller actions to Admin, Manager or Employee roles
- filter work log listings so employees only see their own entries
- block unauthorized edits and deletions with proper `Unauthorized`/`Forbid` responses

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_6890c045aef8832b9d91064ceda4a685