### PR TITLE
Add work log authorization checks

### DIFF
--- a/ProjectTracker.Service/Services/Implementations/WorkLogService.cs
+++ b/ProjectTracker.Service/Services/Implementations/WorkLogService.cs
@@ -48,6 +48,19 @@ namespace ProjectTracker.Service.Services.Implementations
             return _mapper.Map<WorkLogDto>(workLog);
         }
 
+        public async Task<WorkLog> GetWorkLogEntityByIdAsync(int id)
+        {
+            var workLogs = await _workLogRepository.GetAsync(
+                w => w.Id == id,
+                includes: new Expression<Func<WorkLog, object>>[]
+                {
+                    w => w.Project,
+                    w => w.Project.ProjectEmployees
+                });
+
+            return workLogs.FirstOrDefault();
+        }
+
         // Add this method
         public async Task<IEnumerable<WorkLogDto>> GetWorkLogsByUserIdAsync(int userId)
         {

--- a/ProjectTracker.Service/Services/Interfaces/IWorkLogService.cs
+++ b/ProjectTracker.Service/Services/Interfaces/IWorkLogService.cs
@@ -1,4 +1,5 @@
-﻿using ProjectTracker.Service.DTOs;
+﻿using ProjectTracker.Core.Entities;
+using ProjectTracker.Service.DTOs;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -8,6 +9,7 @@ namespace ProjectTracker.Service.Services.Interfaces
     {
         Task<IEnumerable<WorkLogDto>> GetAllWorkLogsAsync();
         Task<WorkLogDto> GetWorkLogByIdAsync(int id);
+        Task<WorkLog> GetWorkLogEntityByIdAsync(int id);
         Task<IEnumerable<WorkLogDto>> GetWorkLogsByUserIdAsync(int userId);
         Task<IEnumerable<WorkLogDto>> GetWorkLogsByProjectIdAsync(int projectId);
         Task<IEnumerable<WorkLogDto>> GetWorkLogsByEmployeeIdAsync(int employeeId);  // Add this method


### PR DESCRIPTION
## Summary
- validate that work logs are accessed only by their owners, project managers, or admins
- gate work log controller actions on authorization results
- expose work-log entity retrieval for authorization checks

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6890c05671c0832b9e373bd22c7722fc