### PR TITLE
Add cost tracking and attachments to work logs, enable employee activation

### DIFF
--- a/ProjectTracker.Core/Entities/Employee.cs
+++ b/ProjectTracker.Core/Entities/Employee.cs
@@ -30,6 +30,8 @@ public class Employee : BaseEntity
 
     public DateTime HireDate { get; set; }
 
+    public bool IsActive { get; set; } = true;
+
     // Link to user account
     public int? UserId { get; set; }
     public virtual ApplicationUser User { get; set; }

--- a/ProjectTracker.Core/Entities/WorkLog.cs
+++ b/ProjectTracker.Core/Entities/WorkLog.cs
@@ -15,6 +15,7 @@ namespace ProjectTracker.Core.Entities
         public string Description { get; set; } = string.Empty;
         public DateTime WorkDate { get; set; }
         public decimal HoursSpent { get; set; }
+        public decimal Cost { get; set; }
 
         public int ProjectId { get; set; }
         public Project Project { get; set; } = null!;

--- a/ProjectTracker.Data/Context/AppDbContext.cs
+++ b/ProjectTracker.Data/Context/AppDbContext.cs
@@ -87,6 +87,9 @@ namespace ProjectTracker.Data.Context
                 entity.Property(e => e.HireDate)
                     .IsRequired();
 
+                entity.Property(e => e.IsActive)
+                    .HasDefaultValue(true);
+
                 // Configure the relationship with ApplicationUser
                 entity.HasOne(e => e.User)
                     .WithOne()
@@ -116,6 +119,10 @@ namespace ProjectTracker.Data.Context
 
                 entity.Property(e => e.HoursSpent)
                     .HasColumnType("decimal(5,2)");
+
+                entity.Property(e => e.Cost)
+                    .HasColumnType("decimal(18,2)")
+                    .HasDefaultValue(0);
 
                 entity.HasOne(e => e.Project)
                     .WithMany(p => p.WorkLogs)

--- a/ProjectTracker.Data/Models/Existing/WorkLog.cs
+++ b/ProjectTracker.Data/Models/Existing/WorkLog.cs
@@ -15,6 +15,8 @@ public partial class WorkLog
 
     public decimal HoursSpent { get; set; }
 
+    public decimal Cost { get; set; }
+
     public int ProjectId { get; set; }
 
     public int EmployeeId { get; set; }

--- a/ProjectTracker.Service/DTOs/WorkLogDto.cs
+++ b/ProjectTracker.Service/DTOs/WorkLogDto.cs
@@ -22,6 +22,10 @@ namespace ProjectTracker.Service.DTOs
         [Range(0.1, 24, ErrorMessage = "Süre 0.1 ile 24 saat arasında olmalıdır")]
         public decimal HoursSpent { get; set; }
 
+        [Display(Name = "Harcanan Para")]
+        [Range(0, double.MaxValue, ErrorMessage = "Maliyet negatif olamaz")]
+        public decimal Cost { get; set; }
+
         [Required(ErrorMessage = "Proje seçimi zorunludur")]
         [Display(Name = "Proje")]
         public int ProjectId { get; set; }

--- a/ProjectTracker.Service/Mapping/MappingProfile.cs
+++ b/ProjectTracker.Service/Mapping/MappingProfile.cs
@@ -27,9 +27,11 @@ namespace ProjectTracker.Service.Mapping
                 .ForMember(dest => dest.Email, opt => opt.MapFrom(src => src.Email))
                 .ForMember(dest => dest.Title, opt => opt.MapFrom(src => src.Title))
                 .ForMember(dest => dest.HireDate, opt => opt.MapFrom(src => src.HireDate))
+                .ForMember(dest => dest.IsActive, opt => opt.MapFrom(src => src.IsActive))
                 .ForMember(dest => dest.Projects,
         opt => opt.MapFrom(src => src.UserProjects.Select(up => up.Project)))
-                .ReverseMap();
+                .ReverseMap()
+                .ForMember(dest => dest.UserProjects, opt => opt.Ignore());
 
             // WorkLog Mappings
             CreateMap<WorkLog, WorkLogDto>()
@@ -38,6 +40,7 @@ namespace ProjectTracker.Service.Mapping
                 .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description))
                 .ForMember(dest => dest.WorkDate, opt => opt.MapFrom(src => src.WorkDate))
                 .ForMember(dest => dest.HoursSpent, opt => opt.MapFrom(src => src.HoursSpent))
+                .ForMember(dest => dest.Cost, opt => opt.MapFrom(src => src.Cost))
                 .ForMember(dest => dest.ProjectId, opt => opt.MapFrom(src => src.ProjectId))
                 .ForMember(dest => dest.EmployeeId, opt => opt.MapFrom(src => src.EmployeeId))
                 .ForMember(dest => dest.ProjectName, opt => opt.MapFrom(src => src.Project != null ? src.Project.Name : string.Empty))
@@ -51,12 +54,13 @@ namespace ProjectTracker.Service.Mapping
                 .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description))
                 .ForMember(dest => dest.WorkDate, opt => opt.MapFrom(src => src.WorkDate))
                 .ForMember(dest => dest.HoursSpent, opt => opt.MapFrom(src => src.HoursSpent))
+                .ForMember(dest => dest.Cost, opt => opt.MapFrom(src => src.Cost))
                 .ForMember(dest => dest.ProjectId, opt => opt.MapFrom(src => src.ProjectId))
                 .ForMember(dest => dest.EmployeeId, opt => opt.MapFrom(src => src.EmployeeId))
                 .ForMember(dest => dest.Project, opt => opt.Ignore())
                 .ForMember(dest => dest.Employee, opt => opt.Ignore())
                 .ForMember(dest => dest.Details, opt => opt.Ignore())
-                .ForMember(dest => dest.Attachments, opt => opt.Ignore())
+                .ForMember(dest => dest.Attachments, opt => opt.MapFrom(src => src.Attachments))
                 .ForMember(dest => dest.CreatedDate, opt => opt.Ignore())
                 .ForMember(dest => dest.UpdatedDate, opt => opt.Ignore())
                 .ForMember(dest => dest.IsActive, opt => opt.Ignore());

--- a/ProjectTracker.Web/Controllers/EmployeeController.cs
+++ b/ProjectTracker.Web/Controllers/EmployeeController.cs
@@ -123,6 +123,7 @@ namespace ProjectTracker.Web.Controllers
         {
             if (ModelState.IsValid)
             {
+                employeeDto.IsActive = true;
                 await _employeeService.CreateEmployeeAsync(employeeDto);
                 TempData["SuccessMessage"] = "Çalışan başarıyla oluşturuldu.";
                 return RedirectToAction(nameof(Index));
@@ -151,7 +152,7 @@ namespace ProjectTracker.Web.Controllers
         [HttpPost]
         [ValidateAntiForgeryToken]
         [Authorize(Roles = "Admin,Manager")]
-        public async Task<IActionResult> Edit(int id, [Bind("Id,FirstName,LastName,Email,Title,HireDate")] EmployeeDto employeeDto)
+        public async Task<IActionResult> Edit(int id, [Bind("Id,FirstName,LastName,Email,Title,HireDate,IsActive")] EmployeeDto employeeDto)
         {
             if (id != employeeDto.Id)
             {

--- a/ProjectTracker.Web/Controllers/WorkLogController.cs
+++ b/ProjectTracker.Web/Controllers/WorkLogController.cs
@@ -1,11 +1,14 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Http;
 using ProjectTracker.Service.DTOs;
 using ProjectTracker.Service.Services.Interfaces;
 using ProjectTracker.Web.ViewModels;
 using System.Security.Claims;
 using ProjectTracker.Web.Authorization;
+using System.IO;
+using System;
 
 namespace ProjectTracker.Web.Controllers
 {
@@ -262,7 +265,7 @@ namespace ProjectTracker.Web.Controllers
         [Authorize(Roles = "Admin,Manager,Employee")]
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create(WorkLogDto workLogDto)
+        public async Task<IActionResult> Create(WorkLogDto workLogDto, IFormFile? attachment)
         {
             if (User.IsInRole("Employee"))
             {
@@ -284,6 +287,29 @@ namespace ProjectTracker.Web.Controllers
 
             if (ModelState.IsValid)
             {
+                if (attachment != null && attachment.Length > 0)
+                {
+                    var uploadsFolder = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot", "uploads");
+                    if (!Directory.Exists(uploadsFolder))
+                        Directory.CreateDirectory(uploadsFolder);
+
+                    var fileName = Path.GetFileName(attachment.FileName);
+                    var uniqueFileName = $"{Guid.NewGuid()}_{fileName}";
+                    var filePath = Path.Combine(uploadsFolder, uniqueFileName);
+                    using (var stream = new FileStream(filePath, FileMode.Create))
+                    {
+                        await attachment.CopyToAsync(stream);
+                    }
+
+                    workLogDto.Attachments.Add(new WorkLogAttachmentDto
+                    {
+                        FileName = fileName,
+                        FilePath = $"/uploads/{uniqueFileName}",
+                        FileType = attachment.ContentType,
+                        FileSize = attachment.Length
+                    });
+                }
+
                 await _workLogService.CreateWorkLogAsync(workLogDto);
                 return RedirectToAction(nameof(Index));
             }

--- a/ProjectTracker.Web/Views/Employee/Edit.cshtml
+++ b/ProjectTracker.Web/Views/Employee/Edit.cshtml
@@ -1,0 +1,60 @@
+@model ProjectTracker.Service.DTOs.EmployeeDto
+@{
+    ViewData["Title"] = "Çalışanı Düzenle";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<hr />
+<div class="row">
+    <div class="col-md-6">
+        <form asp-action="Edit">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <input type="hidden" asp-for="Id" />
+
+            <div class="form-group mb-3">
+                <label asp-for="FirstName" class="control-label">Ad</label>
+                <input asp-for="FirstName" class="form-control" />
+                <span asp-validation-for="FirstName" class="text-danger"></span>
+            </div>
+
+            <div class="form-group mb-3">
+                <label asp-for="LastName" class="control-label">Soyad</label>
+                <input asp-for="LastName" class="form-control" />
+                <span asp-validation-for="LastName" class="text-danger"></span>
+            </div>
+
+            <div class="form-group mb-3">
+                <label asp-for="Email" class="control-label">E-posta</label>
+                <input asp-for="Email" class="form-control" type="email" />
+                <span asp-validation-for="Email" class="text-danger"></span>
+            </div>
+
+            <div class="form-group mb-3">
+                <label asp-for="Title" class="control-label">Ünvan</label>
+                <input asp-for="Title" class="form-control" />
+                <span asp-validation-for="Title" class="text-danger"></span>
+            </div>
+
+            <div class="form-group mb-3">
+                <label asp-for="HireDate" class="control-label">İşe Başlama Tarihi</label>
+                <input asp-for="HireDate" class="form-control" type="date" />
+                <span asp-validation-for="HireDate" class="text-danger"></span>
+            </div>
+
+            <div class="form-group mb-3 form-check">
+                <input asp-for="IsActive" class="form-check-input" />
+                <label asp-for="IsActive" class="form-check-label">Aktif</label>
+            </div>
+
+            <div class="form-group">
+                <input type="submit" value="Kaydet" class="btn btn-primary" />
+                <a asp-action="Index" class="btn btn-secondary">İptal</a>
+            </div>
+        </form>
+    </div>
+</div>
+
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+}

--- a/ProjectTracker.Web/Views/WorkLog/Create.cshtml
+++ b/ProjectTracker.Web/Views/WorkLog/Create.cshtml
@@ -12,7 +12,7 @@
                     <h3><i class="fas fa-plus"></i> Yeni İş Kaydı Oluştur</h3>
                 </div>
                 <div class="card-body">
-                    <form asp-action="Create" method="post">
+                    <form asp-action="Create" method="post" enctype="multipart/form-data">
                         <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
 
                         <div class="mb-3">
@@ -39,6 +39,17 @@
                                 <input asp-for="HoursSpent" type="number" step="0.5" class="form-control" />
                                 <span asp-validation-for="HoursSpent" class="text-danger"></span>
                             </div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label asp-for="Cost" class="form-label"></label>
+                            <input asp-for="Cost" type="number" step="0.01" class="form-control" />
+                            <span asp-validation-for="Cost" class="text-danger"></span>
+                        </div>
+
+                        <div class="mb-3">
+                            <label class="form-label">Dosya Eki</label>
+                            <input type="file" name="attachment" class="form-control" />
                         </div>
 
                         <div class="row">

--- a/tests/ProjectTracker.Tests/EmployeeWorkLogTests.cs
+++ b/tests/ProjectTracker.Tests/EmployeeWorkLogTests.cs
@@ -107,7 +107,7 @@ public class EmployeeWorkLogTests
         var projectRepo = new Repository<Project>(context);
 
         var employeeService = new EmployeeService(employeeRepo, userRepo, mapper, mediator);
-        var workLogService = new WorkLogService(workLogRepo, employeeRepo, userRepo, mapper);
+        var workLogService = new WorkLogService(workLogRepo, employeeRepo, userRepo, projectRepo, mapper);
         var projectService = new ProjectService(projectRepo, mapper);
 
         // Authorization service with custom handler
@@ -144,7 +144,7 @@ public class EmployeeWorkLogTests
             HoursSpent = 2,
             ProjectId = project.Id
         };
-        var createResult = await controller.Create(dto);
+        var createResult = await controller.Create(dto, null);
         Assert.IsType<RedirectToActionResult>(createResult);
 
         var worklogs = await workLogService.GetWorkLogsByEmployeeIdAsync(employee.Id);


### PR DESCRIPTION
## Summary
- allow adding cost and file attachment when creating work logs and update related project cost
- enable marking employees as active or inactive during edit
- expand service and mappings for new work log cost handling

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6891e24189dc832b85ffbfdbb15bcf3b