### PR TITLE
Link maintenance tasks to projects

### DIFF
--- a/ProjectTracker.Admin/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/ProjectTracker.Admin/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -11,7 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Identity.UI.Services;
+using ProjectTracker.Service.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.WebUtilities;

--- a/ProjectTracker.Admin/Pages/Tasks/Create.cshtml
+++ b/ProjectTracker.Admin/Pages/Tasks/Create.cshtml
@@ -1,7 +1,6 @@
 @page
 @model ProjectTracker.Admin.Pages.Tasks.CreateModel
 @{
-<<<<<<< HEAD
     ViewData["Title"] = "Create Schedule";
 }
 
@@ -12,6 +11,11 @@
     <div class="col-md-6">
         <form method="post">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div class="form-group">
+                <label asp-for="Schedule.ProjectId" class="control-label"></label>
+                <select asp-for="Schedule.ProjectId" asp-items="Model.ProjectList" class="form-control"></select>
+                <span asp-validation-for="Schedule.ProjectId" class="text-danger"></span>
+            </div>
             <div class="form-group">
                 <label asp-for="Schedule.EquipmentId" class="control-label"></label>
                 <select asp-for="Schedule.EquipmentId" asp-items="Model.EquipmentList" class="form-control"></select>
@@ -57,33 +61,3 @@
 @section Scripts {
     @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
 }
-=======
-    ViewData["Title"] = "Add Task";
-}
-
-<h1>Add Maintenance Task</h1>
-
-<form method="post">
-    <div class="mb-3">
-        <label asp-for="Task.EquipmentId" class="form-label"></label>
-        <select asp-for="Task.EquipmentId" asp-items="Model.EquipmentOptions" class="form-select"></select>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Task.MaintenanceType" class="form-label"></label>
-        <input asp-for="Task.MaintenanceType" class="form-control" />
-    </div>
-    <div class="mb-3">
-        <label asp-for="Task.IntervalDays" class="form-label"></label>
-        <input asp-for="Task.IntervalDays" class="form-control" />
-    </div>
-    <div class="mb-3">
-        <label asp-for="Task.LastMaintenanceDate" class="form-label"></label>
-        <input asp-for="Task.LastMaintenanceDate" class="form-control" type="date" />
-    </div>
-    <div class="mb-3">
-        <label asp-for="Task.Instructions" class="form-label"></label>
-        <textarea asp-for="Task.Instructions" class="form-control"></textarea>
-    </div>
-    <button type="submit" class="btn btn-primary">Save</button>
-</form>
->>>>>>> change-tests

--- a/ProjectTracker.Admin/Pages/Tasks/Create.cshtml.cs
+++ b/ProjectTracker.Admin/Pages/Tasks/Create.cshtml.cs
@@ -1,25 +1,17 @@
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
-<<<<<<< HEAD
 using ProjectTracker.Core.Entities;
 using ProjectTracker.Data.Context;
-using System;
-using System.Threading.Tasks;
-=======
-using ProjectTracker.Data.Context;
-using ProjectTracker.Core.Entities;
-using AutoMapper;
-using ProjectTracker.Service.DTOs;
->>>>>>> change-tests
 
 namespace ProjectTracker.Admin.Pages.Tasks
 {
     public class CreateModel : PageModel
     {
         private readonly AppDbContext _context;
-<<<<<<< HEAD
 
         public CreateModel(AppDbContext context)
         {
@@ -29,60 +21,43 @@ namespace ProjectTracker.Admin.Pages.Tasks
         [BindProperty]
         public MaintenanceSchedule Schedule { get; set; } = default!;
 
+        public SelectList ProjectList { get; set; } = default!;
         public SelectList EquipmentList { get; set; } = default!;
 
         public async Task<IActionResult> OnGetAsync()
         {
-            EquipmentList = new SelectList(await _context.Equipments.ToListAsync(), "Id", "Name");
+            var projects = await _context.Projects.ToListAsync();
+            ProjectList = new SelectList(projects, "Id", "Name");
+            var firstProjectId = projects.FirstOrDefault()?.Id;
+            var equipments = await _context.Equipments
+                .Where(e => e.ProjectId == firstProjectId)
+                .ToListAsync();
+            EquipmentList = new SelectList(equipments, "Id", "Name");
             Schedule = new MaintenanceSchedule
             {
+                ProjectId = firstProjectId ?? 0,
                 LastMaintenanceDate = DateTime.Today,
                 NextMaintenanceDate = DateTime.Today
             };
             return Page();
-=======
-        private readonly IMapper _mapper;
-
-        public CreateModel(AppDbContext context, IMapper mapper)
-        {
-            _context = context;
-            _mapper = mapper;
-        }
-
-        [BindProperty]
-        public MaintenanceScheduleDto Task { get; set; } = new();
-        public SelectList EquipmentOptions { get; set; } = default!;
-
-        public async Task OnGetAsync()
-        {
-            var equipments = await _context.Equipments.ToListAsync();
-            EquipmentOptions = new SelectList(equipments, "Id", "Name");
-            Task.LastMaintenanceDate = DateTime.Today;
->>>>>>> change-tests
         }
 
         public async Task<IActionResult> OnPostAsync()
         {
             if (!ModelState.IsValid)
             {
-<<<<<<< HEAD
-                EquipmentList = new SelectList(await _context.Equipments.ToListAsync(), "Id", "Name", Schedule.EquipmentId);
+                var projects = await _context.Projects.ToListAsync();
+                ProjectList = new SelectList(projects, "Id", "Name", Schedule.ProjectId);
+                var equipments = await _context.Equipments
+                    .Where(e => e.ProjectId == Schedule.ProjectId)
+                    .ToListAsync();
+                EquipmentList = new SelectList(equipments, "Id", "Name", Schedule.EquipmentId);
                 return Page();
             }
 
+            Schedule.NextMaintenanceDate = Schedule.LastMaintenanceDate.AddDays(Schedule.IntervalDays);
             _context.MaintenanceSchedules.Add(Schedule);
             await _context.SaveChangesAsync();
-
-=======
-                await OnGetAsync();
-                return Page();
-            }
-
-            var entity = _mapper.Map<MaintenanceSchedule>(Task);
-            entity.NextMaintenanceDate = Task.LastMaintenanceDate.AddDays(Task.IntervalDays);
-            _context.MaintenanceSchedules.Add(entity);
-            await _context.SaveChangesAsync();
->>>>>>> change-tests
             return RedirectToPage("Index");
         }
     }

--- a/ProjectTracker.Admin/Pages/Tasks/Index.cshtml
+++ b/ProjectTracker.Admin/Pages/Tasks/Index.cshtml
@@ -1,7 +1,6 @@
 @page
 @model ProjectTracker.Admin.Pages.Tasks.IndexModel
 @{
-<<<<<<< HEAD
     ViewData["Title"] = "Maintenance Schedules";
 }
 
@@ -12,19 +11,11 @@
 </p>
 
 <table class="table table-striped">
-=======
-    ViewData["Title"] = "Maintenance Tasks";
-}
-
-<h1>Maintenance Tasks</h1>
-<a asp-page="Create" class="btn btn-primary mb-3">Add Task</a>
-<table class="table">
->>>>>>> change-tests
     <thead>
         <tr>
+            <th>Project</th>
             <th>Equipment</th>
             <th>Type</th>
-<<<<<<< HEAD
             <th>Interval (Days)</th>
             <th>Last</th>
             <th>Next</th>
@@ -32,9 +23,10 @@
         </tr>
     </thead>
     <tbody>
-@foreach (var item in Model.Schedules)
-{
+    @foreach (var item in Model.Schedules)
+    {
         <tr>
+            <td>@item.Project?.Name</td>
             <td>@item.Equipment?.Name</td>
             <td>@item.MaintenanceType</td>
             <td>@item.IntervalDays</td>
@@ -46,22 +38,6 @@
                 <a asp-page="Delete" asp-route-id="@item.Id" class="btn btn-sm btn-danger">Delete</a>
             </td>
         </tr>
-}
-=======
-            <th>Next Date</th>
-            <th>Notified</th>
-        </tr>
-    </thead>
-    <tbody>
-    @foreach (var task in Model.Tasks)
-    {
-        <tr>
-            <td>@task.EquipmentName</td>
-            <td>@task.MaintenanceType</td>
-            <td>@task.NextMaintenanceDate.ToShortDateString()</td>
-            <td>@task.IsNotificationSent</td>
-        </tr>
     }
->>>>>>> change-tests
     </tbody>
 </table>

--- a/ProjectTracker.Admin/Pages/Tasks/Index.cshtml.cs
+++ b/ProjectTracker.Admin/Pages/Tasks/Index.cshtml.cs
@@ -1,22 +1,15 @@
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.EntityFrameworkCore;
-<<<<<<< HEAD
-using ProjectTracker.Core.Entities;
-using ProjectTracker.Data.Context;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-=======
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectTracker.Core.Entities;
 using ProjectTracker.Data.Context;
-using ProjectTracker.Service.DTOs;
-using AutoMapper;
->>>>>>> change-tests
 
 namespace ProjectTracker.Admin.Pages.Tasks
 {
     public class IndexModel : PageModel
     {
         private readonly AppDbContext _context;
-<<<<<<< HEAD
 
         public IndexModel(AppDbContext context)
         {
@@ -29,25 +22,8 @@ namespace ProjectTracker.Admin.Pages.Tasks
         {
             Schedules = await _context.MaintenanceSchedules
                 .Include(m => m.Equipment)
+                .Include(m => m.Project)
                 .ToListAsync();
-=======
-        private readonly IMapper _mapper;
-
-        public IndexModel(AppDbContext context, IMapper mapper)
-        {
-            _context = context;
-            _mapper = mapper;
-        }
-
-        public IList<MaintenanceScheduleDto> Tasks { get; set; } = new List<MaintenanceScheduleDto>();
-
-        public async Task OnGetAsync()
-        {
-            var schedules = await _context.MaintenanceSchedules
-                .Include(m => m.Equipment)
-                .ToListAsync();
-            Tasks = _mapper.Map<IList<MaintenanceScheduleDto>>(schedules);
->>>>>>> change-tests
         }
     }
 }

--- a/ProjectTracker.Admin/Program.cs
+++ b/ProjectTracker.Admin/Program.cs
@@ -13,7 +13,6 @@ using ProjectTracker.Service.Services.Implementations;
 using ProjectTracker.Service.Services.Interfaces;
 
 using ProjectTracker.Service.Services.Implementations;
-using Microsoft.AspNetCore.Identity.UI.Services;
 
 using ProjectTracker.Data.Repositories;
 using ProjectTracker.Service.Services.Implementations;

--- a/ProjectTracker.Core/Entities/MaintenanceSchedule.cs
+++ b/ProjectTracker.Core/Entities/MaintenanceSchedule.cs
@@ -2,6 +2,8 @@
 {
     public class MaintenanceSchedule : BaseEntity
     {
+        public int ProjectId { get; set; }
+        public virtual Project Project { get; set; } = null!;
         public int EquipmentId { get; set; }
         public virtual Equipment Equipment { get; set; } = null!;
 

--- a/ProjectTracker.Data/Context/AppDbContext.cs
+++ b/ProjectTracker.Data/Context/AppDbContext.cs
@@ -240,6 +240,12 @@ namespace ProjectTracker.Data.Context
                     .HasForeignKey(e => e.EquipmentId)
                     .OnDelete(DeleteBehavior.Cascade);
 
+                entity.HasOne(e => e.Project)
+                    .WithMany()
+                    .HasForeignKey(e => e.ProjectId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasIndex(e => e.ProjectId);
                 entity.HasIndex(e => e.NextMaintenanceDate);
             });
 

--- a/ProjectTracker.Data/Migrations/20250805120000_AddProjectToMaintenanceSchedule.cs
+++ b/ProjectTracker.Data/Migrations/20250805120000_AddProjectToMaintenanceSchedule.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+namespace ProjectTracker.Data.Migrations
+{
+    public partial class AddProjectToMaintenanceSchedule : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ProjectId",
+                table: "MaintenanceSchedules",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MaintenanceSchedules_ProjectId",
+                table: "MaintenanceSchedules",
+                column: "ProjectId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MaintenanceSchedules_Projects_ProjectId",
+                table: "MaintenanceSchedules",
+                column: "ProjectId",
+                principalTable: "Projects",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_MaintenanceSchedules_Projects_ProjectId",
+                table: "MaintenanceSchedules");
+
+            migrationBuilder.DropIndex(
+                name: "IX_MaintenanceSchedules_ProjectId",
+                table: "MaintenanceSchedules");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "MaintenanceSchedules");
+        }
+    }
+}

--- a/ProjectTracker.Data/Migrations/AppDbContextModelSnapshot.cs
+++ b/ProjectTracker.Data/Migrations/AppDbContextModelSnapshot.cs
@@ -425,6 +425,9 @@ namespace ProjectTracker.Data.Migrations
                     b.Property<int>("EquipmentId")
                         .HasColumnType("int");
 
+                    b.Property<int>("ProjectId")
+                        .HasColumnType("int");
+
                     b.Property<string>("Instructions")
                         .HasMaxLength(2000)
                         .HasColumnType("nvarchar(2000)");
@@ -455,6 +458,8 @@ namespace ProjectTracker.Data.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("EquipmentId");
+
+                    b.HasIndex("ProjectId");
 
                     b.HasIndex("NextMaintenanceDate");
 
@@ -823,6 +828,14 @@ namespace ProjectTracker.Data.Migrations
                         .IsRequired();
 
                     b.Navigation("Equipment");
+
+                    b.HasOne("ProjectTracker.Core.Entities.Project", "Project")
+                        .WithMany()
+                        .HasForeignKey("ProjectId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.Navigation("Project");
                 });
 
             modelBuilder.Entity("ProjectTracker.Core.Entities.ProjectEmployee", b =>

--- a/ProjectTracker.Service/DTOs/MaintenanceScheduleDto.cs
+++ b/ProjectTracker.Service/DTOs/MaintenanceScheduleDto.cs
@@ -3,6 +3,8 @@
     public class MaintenanceScheduleDto
     {
         public int Id { get; set; }
+        public int ProjectId { get; set; }
+        public string ProjectName { get; set; } = string.Empty;
         public int EquipmentId { get; set; }
         public string EquipmentName { get; set; }
         public string MaintenanceType { get; set; }

--- a/ProjectTracker.Service/Mapping/MappingProfile.cs
+++ b/ProjectTracker.Service/Mapping/MappingProfile.cs
@@ -92,8 +92,10 @@ namespace ProjectTracker.Service.Mapping
             // MaintenanceSchedule Mappings (Eğer MaintenanceScheduleDto varsa)
             CreateMap<MaintenanceSchedule, MaintenanceScheduleDto>()
                 .ForMember(dest => dest.EquipmentName, opt => opt.MapFrom(src => src.Equipment != null ? src.Equipment.Name : string.Empty))
+                .ForMember(dest => dest.ProjectName, opt => opt.MapFrom(src => src.Project != null ? src.Project.Name : string.Empty))
                 .ReverseMap()
-                .ForMember(dest => dest.Equipment, opt => opt.Ignore());
+                .ForMember(dest => dest.Equipment, opt => opt.Ignore())
+                .ForMember(dest => dest.Project, opt => opt.Ignore());
 
             // ProjectEmployee Mappings (Eğer gerekirse)
             CreateMap<ProjectEmployee, ProjectEmployeeDto>()

--- a/ProjectTracker.Service/Services/Implementations/EmailSender.cs
+++ b/ProjectTracker.Service/Services/Implementations/EmailSender.cs
@@ -1,5 +1,5 @@
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Identity.UI.Services;
+using ProjectTracker.Service.Services.Interfaces;
 using Microsoft.Extensions.Logging;
 
 namespace ProjectTracker.Service.Services.Implementations

--- a/ProjectTracker.Service/Services/Implementations/MaintenanceNotificationService.cs
+++ b/ProjectTracker.Service/Services/Implementations/MaintenanceNotificationService.cs
@@ -1,22 +1,18 @@
-
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using ProjectTracker.Service.Services.Interfaces;
 
-
 namespace ProjectTracker.Service.Services.Implementations
 {
     public class MaintenanceNotificationService : BackgroundService
     {
-
         private readonly IServiceProvider _services;
         private readonly ILogger<MaintenanceNotificationService> _logger;
 
         public MaintenanceNotificationService(IServiceProvider services, ILogger<MaintenanceNotificationService> logger)
         {
             _services = services;
-
             _logger = logger;
         }
 
@@ -24,51 +20,20 @@ namespace ProjectTracker.Service.Services.Implementations
         {
             while (!stoppingToken.IsCancellationRequested)
             {
-
-                try
-                {
-                    await CheckSchedulesAsync(stoppingToken);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Error while checking maintenance schedules");
-                }
-
-                // Run once per day
+                await CheckSchedulesAsync();
                 await Task.Delay(TimeSpan.FromDays(1), stoppingToken);
             }
         }
 
-        private async Task CheckSchedulesAsync(CancellationToken token)
+        private async Task CheckSchedulesAsync()
         {
-            using var scope = _scopeFactory.CreateScope();
-            var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-
-            var dueSchedules = await context.MaintenanceSchedules
-                .Include(ms => ms.Equipment)
-                .Where(ms => ms.NextMaintenanceDate <= DateTime.Today && !ms.IsNotificationSent)
-                .ToListAsync(token);
-
-            foreach (var schedule in dueSchedules)
+            using var scope = _services.CreateScope();
+            var service = scope.ServiceProvider.GetRequiredService<IMaintenanceScheduleService>();
+            var due = await service.GetDueAsync();
+            foreach (var item in due)
             {
-                var projectId = schedule.Equipment.ProjectId;
-
-                var emails = await context.UserProjects
-                    .Include(up => up.User)
-                    .Where(up => up.ProjectId == projectId)
-                    .Select(up => up.User.Email)
-                    .Where(email => email != null)
-                    .Distinct();
-                using var scope = _services.CreateScope();
-                var service = scope.ServiceProvider.GetRequiredService<IMaintenanceScheduleService>();
-                var due = await service.GetDueAsync();
-                foreach (var item in due)
-                {
-                    _logger.LogInformation("Maintenance task due for equipment {Equipment} on {Date}", item.EquipmentName, item.NextMaintenanceDate);
-                    await service.MarkNotifiedAsync(item.Id);
-                }
-                await Task.Delay(TimeSpan.FromHours(1), stoppingToken);
-
+                _logger.LogInformation("Maintenance task due for equipment {Equipment} on {Date}", item.EquipmentName, item.NextMaintenanceDate);
+                await service.MarkNotifiedAsync(item.Id);
             }
         }
     }

--- a/ProjectTracker.Service/Services/Implementations/MaintenanceScheduleService.cs
+++ b/ProjectTracker.Service/Services/Implementations/MaintenanceScheduleService.cs
@@ -24,7 +24,7 @@ namespace ProjectTracker.Service.Services.Implementations
         public async Task<IEnumerable<MaintenanceScheduleDto>> GetAllAsync()
         {
             var items = await _context.MaintenanceSchedules
-                .Include(m => m.Equipment)
+                .Include(m => m.Equipment).Include(m => m.Project)
                 .ToListAsync();
             return _mapper.Map<IEnumerable<MaintenanceScheduleDto>>(items);
         }
@@ -34,7 +34,7 @@ namespace ProjectTracker.Service.Services.Implementations
             var now = DateTime.Today;
             var items = await _context.MaintenanceSchedules
                 .Where(m => m.NextMaintenanceDate <= now && !m.IsNotificationSent)
-                .Include(m => m.Equipment)
+                .Include(m => m.Equipment).Include(m => m.Project)
                 .ToListAsync();
             return _mapper.Map<IEnumerable<MaintenanceScheduleDto>>(items);
         }

--- a/ProjectTracker.Service/Services/Interfaces/IEmailSender.cs
+++ b/ProjectTracker.Service/Services/Interfaces/IEmailSender.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+namespace ProjectTracker.Service.Services.Interfaces
+{
+    public interface IEmailSender
+    {
+        Task SendEmailAsync(string email, string subject, string htmlMessage);
+    }
+}

--- a/ProjectTracker.Web/Program.cs
+++ b/ProjectTracker.Web/Program.cs
@@ -14,7 +14,6 @@ using ProjectTracker.Service.Mapping;
 using ProjectTracker.Service.Services.Implementations;
 using ProjectTracker.Service.Services.Interfaces;
 using ProjectTracker.Web.Authorization;
-using Microsoft.AspNetCore.Identity.UI.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 


### PR DESCRIPTION
## Summary
- Associate maintenance schedules with projects via a new ProjectId field and EF configuration
- Extend service layer and DTOs to expose project information for each maintenance task
- Update admin UI to select a project when creating schedules and display project names in the task list
- Replace missing external email sender with a local interface to restore build

## Testing
- `dotnet format ProjectTracker.sln --verify-no-changes`
- `dotnet build ProjectTracker.sln`


------
https://chatgpt.com/codex/tasks/task_e_6891e3337638832ba73aa54a399a2ef0