### PR TITLE
Link maintenance tasks to projects

### DIFF
--- a/ProjectTracker.Admin/Pages/Tasks/Create.cshtml
+++ b/ProjectTracker.Admin/Pages/Tasks/Create.cshtml
@@ -8,6 +8,10 @@
 
 <form method="post">
     <div class="mb-3">
+        <label asp-for="Task.ProjectId" class="form-label"></label>
+        <select asp-for="Task.ProjectId" asp-items="Model.ProjectOptions" class="form-select" onchange="location.href='?projectId=' + this.value"></select>
+    </div>
+    <div class="mb-3">
         <label asp-for="Task.EquipmentId" class="form-label"></label>
         <select asp-for="Task.EquipmentId" asp-items="Model.EquipmentOptions" class="form-select"></select>
     </div>

--- a/ProjectTracker.Admin/Pages/Tasks/Create.cshtml.cs
+++ b/ProjectTracker.Admin/Pages/Tasks/Create.cshtml.cs
@@ -6,6 +6,7 @@ using ProjectTracker.Data.Context;
 using ProjectTracker.Core.Entities;
 using AutoMapper;
 using ProjectTracker.Service.DTOs;
+using System.Linq;
 
 namespace ProjectTracker.Admin.Pages.Tasks
 {
@@ -23,10 +24,17 @@ namespace ProjectTracker.Admin.Pages.Tasks
         [BindProperty]
         public MaintenanceScheduleDto Task { get; set; } = new();
         public SelectList EquipmentOptions { get; set; } = default!;
+        public SelectList ProjectOptions { get; set; } = default!;
 
-        public async Task OnGetAsync()
+        public async Task OnGetAsync(int? projectId)
         {
-            var equipments = await _context.Equipments.ToListAsync();
+            var projects = await _context.Projects.ToListAsync();
+            ProjectOptions = new SelectList(projects, "Id", "Name");
+            Task.ProjectId = projectId ?? (projects.FirstOrDefault()?.Id ?? 0);
+
+            var equipments = await _context.Equipments
+                .Where(e => e.ProjectId == Task.ProjectId)
+                .ToListAsync();
             EquipmentOptions = new SelectList(equipments, "Id", "Name");
             Task.LastMaintenanceDate = DateTime.Today;
         }
@@ -35,9 +43,18 @@ namespace ProjectTracker.Admin.Pages.Tasks
         {
             if (!ModelState.IsValid)
             {
-                await OnGetAsync();
+                await OnGetAsync(Task.ProjectId);
                 return Page();
             }
+
+            var equipment = await _context.Equipments.FindAsync(Task.EquipmentId);
+            if (equipment == null)
+            {
+                ModelState.AddModelError("Task.EquipmentId", "Invalid equipment selected.");
+                await OnGetAsync(Task.ProjectId);
+                return Page();
+            }
+            Task.ProjectId = equipment.ProjectId ?? Task.ProjectId;
 
             var entity = _mapper.Map<MaintenanceSchedule>(Task);
             entity.NextMaintenanceDate = Task.LastMaintenanceDate.AddDays(Task.IntervalDays);

--- a/ProjectTracker.Admin/Pages/Tasks/Index.cshtml
+++ b/ProjectTracker.Admin/Pages/Tasks/Index.cshtml
@@ -9,6 +9,7 @@
 <table class="table">
     <thead>
         <tr>
+            <th>Project</th>
             <th>Equipment</th>
             <th>Type</th>
             <th>Next Date</th>
@@ -19,6 +20,7 @@
     @foreach (var task in Model.Tasks)
     {
         <tr>
+            <td>@task.ProjectName</td>
             <td>@task.EquipmentName</td>
             <td>@task.MaintenanceType</td>
             <td>@task.NextMaintenanceDate.ToShortDateString()</td>

--- a/ProjectTracker.Admin/Pages/Tasks/Index.cshtml.cs
+++ b/ProjectTracker.Admin/Pages/Tasks/Index.cshtml.cs
@@ -23,6 +23,7 @@ namespace ProjectTracker.Admin.Pages.Tasks
         {
             var schedules = await _context.MaintenanceSchedules
                 .Include(m => m.Equipment)
+                .Include(m => m.Project)
                 .ToListAsync();
             Tasks = _mapper.Map<IList<MaintenanceScheduleDto>>(schedules);
         }

--- a/ProjectTracker.Core/Entities/MaintenanceSchedule.cs
+++ b/ProjectTracker.Core/Entities/MaintenanceSchedule.cs
@@ -5,6 +5,9 @@
         public int EquipmentId { get; set; }
         public virtual Equipment Equipment { get; set; } = null!;
 
+        public int ProjectId { get; set; }
+        public virtual Project Project { get; set; } = null!;
+
         public string MaintenanceType { get; set; } = string.Empty;
         public int IntervalDays { get; set; }
         public DateTime LastMaintenanceDate { get; set; }

--- a/ProjectTracker.Core/Entities/Project.cs
+++ b/ProjectTracker.Core/Entities/Project.cs
@@ -10,6 +10,7 @@ namespace ProjectTracker.Core.Entities
             WorkLogs = new HashSet<WorkLog>();
             ProjectEmployees = new HashSet<ProjectEmployee>();
             Equipments = new HashSet<Equipment>(); // Yeni eklendi
+            MaintenanceSchedules = new HashSet<MaintenanceSchedule>();
         }
 
         public string Name { get; set; } = string.Empty;
@@ -22,5 +23,6 @@ namespace ProjectTracker.Core.Entities
         public ICollection<WorkLog> WorkLogs { get; set; }
         public ICollection<ProjectEmployee> ProjectEmployees { get; set; }
         public virtual ICollection<Equipment> Equipments { get; set; } = [];// Yeni eklendi
+        public virtual ICollection<MaintenanceSchedule> MaintenanceSchedules { get; set; } = [];
     }
 }

--- a/ProjectTracker.Data/Context/AppDbContext.cs
+++ b/ProjectTracker.Data/Context/AppDbContext.cs
@@ -247,6 +247,11 @@ namespace ProjectTracker.Data.Context
                     .HasForeignKey(e => e.EquipmentId)
                     .OnDelete(DeleteBehavior.Cascade);
 
+                entity.HasOne(e => e.Project)
+                    .WithMany(p => p.MaintenanceSchedules)
+                    .HasForeignKey(e => e.ProjectId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
                 entity.HasIndex(e => e.NextMaintenanceDate);
             });
 

--- a/ProjectTracker.Data/Migrations/20250805112720_AddProjectToMaintenanceSchedule.Designer.cs
+++ b/ProjectTracker.Data/Migrations/20250805112720_AddProjectToMaintenanceSchedule.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ProjectTracker.Data.Context;
 
@@ -11,9 +12,11 @@ using ProjectTracker.Data.Context;
 namespace ProjectTracker.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250805112720_AddProjectToMaintenanceSchedule")]
+    partial class AddProjectToMaintenanceSchedule
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ProjectTracker.Data/Migrations/20250805112720_AddProjectToMaintenanceSchedule.cs
+++ b/ProjectTracker.Data/Migrations/20250805112720_AddProjectToMaintenanceSchedule.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProjectToMaintenanceSchedule : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ProjectId",
+                table: "MaintenanceSchedules",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MaintenanceSchedules_ProjectId",
+                table: "MaintenanceSchedules",
+                column: "ProjectId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MaintenanceSchedules_Projects_ProjectId",
+                table: "MaintenanceSchedules",
+                column: "ProjectId",
+                principalTable: "Projects",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_MaintenanceSchedules_Projects_ProjectId",
+                table: "MaintenanceSchedules");
+
+            migrationBuilder.DropIndex(
+                name: "IX_MaintenanceSchedules_ProjectId",
+                table: "MaintenanceSchedules");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "MaintenanceSchedules");
+        }
+    }
+}

--- a/ProjectTracker.Service/DTOs/MaintenanceScheduleDto.cs
+++ b/ProjectTracker.Service/DTOs/MaintenanceScheduleDto.cs
@@ -5,6 +5,8 @@
         public int Id { get; set; }
         public int EquipmentId { get; set; }
         public string EquipmentName { get; set; }
+        public int ProjectId { get; set; }
+        public string ProjectName { get; set; }
         public string MaintenanceType { get; set; }
         public int IntervalDays { get; set; }
         public DateTime LastMaintenanceDate { get; set; }

--- a/ProjectTracker.Service/Mapping/MappingProfile.cs
+++ b/ProjectTracker.Service/Mapping/MappingProfile.cs
@@ -96,8 +96,10 @@ namespace ProjectTracker.Service.Mapping
             // MaintenanceSchedule Mappings (Eğer MaintenanceScheduleDto varsa)
             CreateMap<MaintenanceSchedule, MaintenanceScheduleDto>()
                 .ForMember(dest => dest.EquipmentName, opt => opt.MapFrom(src => src.Equipment != null ? src.Equipment.Name : string.Empty))
+                .ForMember(dest => dest.ProjectName, opt => opt.MapFrom(src => src.Project != null ? src.Project.Name : string.Empty))
                 .ReverseMap()
-                .ForMember(dest => dest.Equipment, opt => opt.Ignore());
+                .ForMember(dest => dest.Equipment, opt => opt.Ignore())
+                .ForMember(dest => dest.Project, opt => opt.Ignore());
 
             // ProjectEmployee Mappings (Eğer gerekirse)
             CreateMap<ProjectEmployee, ProjectEmployeeDto>()

--- a/ProjectTracker.Service/Services/Implementations/MaintenanceScheduleService.cs
+++ b/ProjectTracker.Service/Services/Implementations/MaintenanceScheduleService.cs
@@ -22,6 +22,7 @@ namespace ProjectTracker.Service.Services.Implementations
         {
             var items = await _context.MaintenanceSchedules
                 .Include(m => m.Equipment)
+                .Include(m => m.Project)
                 .ToListAsync();
             return _mapper.Map<IEnumerable<MaintenanceScheduleDto>>(items);
         }
@@ -32,6 +33,7 @@ namespace ProjectTracker.Service.Services.Implementations
             var items = await _context.MaintenanceSchedules
                 .Where(m => m.NextMaintenanceDate <= now && !m.IsNotificationSent)
                 .Include(m => m.Equipment)
+                .Include(m => m.Project)
                 .ToListAsync();
             return _mapper.Map<IEnumerable<MaintenanceScheduleDto>>(items);
         }


### PR DESCRIPTION
## Summary
- relate maintenance schedules to projects with new ProjectId and mapping
- show project selection and filtering when creating maintenance tasks
- display project info in task listings

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6891e8f7a1ac832ba0ea6707e2861cd8