### PR TITLE
Fix maintenance schedule dto defaults

### DIFF
--- a/ProjectTracker.Service/DTOs/MaintenanceScheduleDto.cs
+++ b/ProjectTracker.Service/DTOs/MaintenanceScheduleDto.cs
@@ -4,14 +4,14 @@
     {
         public int Id { get; set; }
         public int EquipmentId { get; set; }
-        public string EquipmentName { get; set; }
+        public string EquipmentName { get; set; } = string.Empty;
         public int ProjectId { get; set; }
-        public string ProjectName { get; set; }
-        public string MaintenanceType { get; set; }
+        public string ProjectName { get; set; } = string.Empty;
+        public string MaintenanceType { get; set; } = string.Empty;
         public int IntervalDays { get; set; }
         public DateTime LastMaintenanceDate { get; set; }
         public DateTime NextMaintenanceDate { get; set; }
-        public string Instructions { get; set; }
+        public string Instructions { get; set; } = string.Empty;
         public bool IsNotificationSent { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- avoid validation errors when creating maintenance schedules by defaulting optional text fields

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6892fcd4fa74832bbe545ae21158c641