### PR TITLE
Add employee activation toggle in Manage Roles

### DIFF
--- a/ProjectTracker.Admin/Pages/Users/ManageRoles.cshtml
+++ b/ProjectTracker.Admin/Pages/Users/ManageRoles.cshtml
@@ -32,6 +32,13 @@
 
                     <dt class="col-sm-3">Full Name:</dt>
                     <dd class="col-sm-9">@Model.UserRoles.FullName</dd>
+
+                    <dt class="col-sm-3">Status:</dt>
+                    <dd class="col-sm-9">
+                        <span class="badge @(Model.UserRoles.IsActive ? "bg-success" : "bg-secondary")">
+                            @(Model.UserRoles.IsActive ? "Active" : "Inactive")
+                        </span>
+                    </dd>
                 </dl>
             </div>
         </div>
@@ -48,6 +55,11 @@
                     <input type="hidden" asp-for="UserRoles.FullName" />
 
                     <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+                    <div class="form-check form-switch mb-3">
+                        <input class="form-check-input" asp-for="UserRoles.IsActive" />
+                        <label class="form-check-label" asp-for="UserRoles.IsActive"></label>
+                    </div>
 
                     <div class="table-responsive">
                         <table class="table table-hover">
@@ -67,7 +79,7 @@
                                             <input type="hidden" asp-for="UserRoles.Roles[i].RoleName" />
                                             <input type="hidden" asp-for="UserRoles.Roles[i].Description" />
                                             <input type="checkbox" asp-for="UserRoles.Roles[i].IsAssigned"
-                                                   class="form-check-input" />
+                                                   class="form-check-input role-checkbox" />
                                         </td>
                                         <td>
                                             <strong>@Model.UserRoles.Roles[i].RoleName</strong>
@@ -141,7 +153,7 @@
 @section Scripts {
     <script>
         // Add visual feedback when checkboxes are changed
-        document.querySelectorAll('input[type="checkbox"]').forEach(function(checkbox) {
+        document.querySelectorAll('.role-checkbox').forEach(function(checkbox) {
             checkbox.addEventListener('change', function() {
                 var row = this.closest('tr');
                 if (this.checked) {

--- a/ProjectTracker.Admin/Pages/Users/ManageRoles.cshtml.cs
+++ b/ProjectTracker.Admin/Pages/Users/ManageRoles.cshtml.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using ProjectTracker.Core.Entities;
 using Microsoft.AspNetCore.Authorization;
 using System.ComponentModel.DataAnnotations;
+using ProjectTracker.Data.Context;
 
 namespace ProjectTracker.Admin.Pages.Users
 {
@@ -14,15 +15,18 @@ namespace ProjectTracker.Admin.Pages.Users
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly RoleManager<ApplicationRole> _roleManager;
         private readonly ILogger<ManageRolesModel> _logger;
+        private readonly AppDbContext _context;
 
         public ManageRolesModel(
             UserManager<ApplicationUser> userManager,
             RoleManager<ApplicationRole> roleManager,
-            ILogger<ManageRolesModel> logger)
+            ILogger<ManageRolesModel> logger,
+            AppDbContext context)
         {
             _userManager = userManager;
             _roleManager = roleManager;
             _logger = logger;
+            _context = context;
         }
 
         [BindProperty]
@@ -34,6 +38,8 @@ namespace ProjectTracker.Admin.Pages.Users
             public string UserName { get; set; }
             public string Email { get; set; }
             public string FullName { get; set; }
+            [Display(Name = "Active")]
+            public bool IsActive { get; set; }
             public List<RoleViewModel> Roles { get; set; } = new List<RoleViewModel>();
         }
 
@@ -52,7 +58,10 @@ namespace ProjectTracker.Admin.Pages.Users
                 return NotFound();
             }
 
-            var user = await _userManager.FindByIdAsync(id.ToString());
+            var user = await _userManager.Users
+                .IgnoreQueryFilters()
+                .Include(u => u.Employee)
+                .FirstOrDefaultAsync(u => u.Id == id);
             if (user == null)
             {
                 return NotFound();
@@ -63,7 +72,8 @@ namespace ProjectTracker.Admin.Pages.Users
                 UserId = user.Id,
                 UserName = user.UserName,
                 Email = user.Email,
-                FullName = $"{user.FirstName} {user.LastName}"
+                FullName = $"{user.FirstName} {user.LastName}",
+                IsActive = user.Employee?.IsActive ?? false
             };
 
             // Get all roles
@@ -91,7 +101,10 @@ namespace ProjectTracker.Admin.Pages.Users
                 return Page();
             }
 
-            var user = await _userManager.FindByIdAsync(UserRoles.UserId.ToString());
+            var user = await _userManager.Users
+                .IgnoreQueryFilters()
+                .Include(u => u.Employee)
+                .FirstOrDefaultAsync(u => u.Id == UserRoles.UserId);
             if (user == null)
             {
                 return NotFound();
@@ -154,6 +167,13 @@ namespace ProjectTracker.Admin.Pages.Users
             {
                 // Reload roles if there were errors
                 return await OnGetAsync(UserRoles.UserId);
+            }
+
+            if (user.Employee != null)
+            {
+                user.Employee.IsActive = UserRoles.IsActive;
+                _context.Update(user.Employee);
+                await _context.SaveChangesAsync();
             }
 
             TempData["Success"] = $"Roles updated successfully for user {user.UserName}.";


### PR DESCRIPTION
## Summary
- allow admins to activate/deactivate employees while managing user roles
- ensure inactive employees can be loaded and updated by ignoring query filters

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6893009fc858832b87ec3b6e5357e4f5