### PR TITLE
Add user detail view and actions in admin Users list

### DIFF
--- a/ProjectTracker.Admin/Pages/Users/Details.cshtml
+++ b/ProjectTracker.Admin/Pages/Users/Details.cshtml
@@ -1,0 +1,82 @@
+@page "{id:int}"
+@model ProjectTracker.Admin.Pages.Users.DetailsModel
+@{
+    ViewData["Title"] = "User Details";
+}
+
+<h1>User Details</h1>
+
+<div class="row">
+    <div class="col-md-8">
+        <div class="card mb-3">
+            <div class="card-header">
+                <h4 class="card-title">Account Information</h4>
+            </div>
+            <div class="card-body">
+                <dl class="row mb-0">
+                    <dt class="col-sm-4">Username</dt>
+                    <dd class="col-sm-8">@Model.UserDetails.UserName</dd>
+
+                    <dt class="col-sm-4">Email</dt>
+                    <dd class="col-sm-8">@Model.UserDetails.Email</dd>
+
+                    <dt class="col-sm-4">Name</dt>
+                    <dd class="col-sm-8">@Model.UserDetails.FirstName @Model.UserDetails.LastName</dd>
+
+                    <dt class="col-sm-4">Employee ID</dt>
+                    <dd class="col-sm-8">@Model.UserDetails.EmployeeId</dd>
+
+                    <dt class="col-sm-4">Phone Number</dt>
+                    <dd class="col-sm-8">@Model.UserDetails.PhoneNumber</dd>
+
+                    <dt class="col-sm-4">Email Confirmed</dt>
+                    <dd class="col-sm-8">@(Model.UserDetails.EmailConfirmed ? "Yes" : "No")</dd>
+
+                    <dt class="col-sm-4">Two-Factor Enabled</dt>
+                    <dd class="col-sm-8">@(Model.UserDetails.TwoFactorEnabled ? "Yes" : "No")</dd>
+
+                    <dt class="col-sm-4">Account Locked</dt>
+                    <dd class="col-sm-8">
+                        @if (Model.UserDetails.IsLocked)
+                        {
+                            <span class="badge bg-danger">Yes (until @Model.UserDetails.LockoutEnd?.LocalDateTime.ToString("g"))</span>
+                        }
+                        else
+                        {
+                            <span class="badge bg-success">No</span>
+                        }
+                    </dd>
+                </dl>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card mb-3">
+            <div class="card-header">
+                <h5 class="card-title">Roles</h5>
+            </div>
+            <div class="card-body">
+                @if (Model.UserDetails.Roles.Any())
+                {
+                    <ul class="mb-0">
+                        @foreach (var role in Model.UserDetails.Roles)
+                        {
+                            <li>@role</li>
+                        }
+                    </ul>
+                }
+                else
+                {
+                    <p class="mb-0">No roles assigned.</p>
+                }
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="mt-3">
+    <a asp-page="./Edit" asp-route-id="@Model.UserDetails.Id" class="btn btn-warning">Edit</a>
+    <a asp-page="./ManageRoles" asp-route-id="@Model.UserDetails.Id" class="btn btn-info">Manage Roles</a>
+    <a asp-page="./Index" class="btn btn-secondary">Back to List</a>
+</div>
+

--- a/ProjectTracker.Admin/Pages/Users/Details.cshtml.cs
+++ b/ProjectTracker.Admin/Pages/Users/Details.cshtml.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Identity;
+using ProjectTracker.Core.Entities;
+using Microsoft.AspNetCore.Authorization;
+
+namespace ProjectTracker.Admin.Pages.Users
+{
+    [Authorize(Roles = "Admin")]
+    public class DetailsModel : PageModel
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public DetailsModel(UserManager<ApplicationUser> userManager)
+        {
+            _userManager = userManager;
+        }
+
+        public UserDetailsViewModel UserDetails { get; set; }
+
+        public class UserDetailsViewModel
+        {
+            public int Id { get; set; }
+            public string UserName { get; set; }
+            public string Email { get; set; }
+            public string FirstName { get; set; }
+            public string LastName { get; set; }
+            public int? EmployeeId { get; set; }
+            public string PhoneNumber { get; set; }
+            public bool EmailConfirmed { get; set; }
+            public bool TwoFactorEnabled { get; set; }
+            public bool IsLocked { get; set; }
+            public DateTimeOffset? LockoutEnd { get; set; }
+            public IList<string> Roles { get; set; }
+        }
+
+        public async Task<IActionResult> OnGetAsync(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var user = await _userManager.FindByIdAsync(id.ToString());
+            if (user == null)
+            {
+                return NotFound();
+            }
+
+            var roles = await _userManager.GetRolesAsync(user);
+
+            UserDetails = new UserDetailsViewModel
+            {
+                Id = user.Id,
+                UserName = user.UserName,
+                Email = user.Email,
+                FirstName = user.FirstName,
+                LastName = user.LastName,
+                EmployeeId = user.EmployeeId,
+                PhoneNumber = user.PhoneNumber,
+                EmailConfirmed = user.EmailConfirmed,
+                TwoFactorEnabled = user.TwoFactorEnabled,
+                IsLocked = user.LockoutEnd.HasValue && user.LockoutEnd > DateTimeOffset.Now,
+                LockoutEnd = user.LockoutEnd,
+                Roles = roles
+            };
+
+            return Page();
+        }
+    }
+}
+

--- a/ProjectTracker.Admin/Pages/Users/Index.cshtml
+++ b/ProjectTracker.Admin/Pages/Users/Index.cshtml
@@ -54,8 +54,9 @@
                     }
                 </td>
                 <td>
-                    <a asp-page="./ManageRoles" asp-route-id="@user.Id.ToString()" class="btn btn-info btn-sm">Manage Roles</a>
+                    <a asp-page="./Details" asp-route-id="@user.Id.ToString()" class="btn btn-primary btn-sm">View</a>
                     <a asp-page="./Edit" asp-route-id="@user.Id.ToString()" class="btn btn-warning btn-sm">Edit</a>
+                    <a asp-page="./ManageRoles" asp-route-id="@user.Id.ToString()" class="btn btn-info btn-sm">Manage Roles</a>
                     <form method="post" asp-page-handler="Delete" asp-route-id="@user.Id.ToString()" class="d-inline"
                           onsubmit="return confirm('Are you sure you want to delete this user?');">
                         <button type="submit" class="btn btn-danger btn-sm">Delete</button>


### PR DESCRIPTION
## Summary
- add view link to user list with manage roles and edit
- implement user details page showing account info and roles

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68934f45b9bc832bb8746ee04090c18f