### PR TITLE
Add user activation toggle

### DIFF
--- a/ProjectTracker.Admin/Pages/Users/Edit.cshtml
+++ b/ProjectTracker.Admin/Pages/Users/Edit.cshtml
@@ -102,6 +102,17 @@
                         </div>
                     </div>
 
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="mb-3">
+                                <div class="form-check form-switch">
+                                    <input asp-for="Input.IsActive" class="form-check-input" />
+                                    <label asp-for="Input.IsActive" class="form-check-label"></label>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
                     <div class="mb-3">
                         <div class="form-check">
                             <input asp-for="Input.IsLocked" class="form-check-input" />

--- a/ProjectTracker.Admin/Pages/Users/Edit.cshtml.cs
+++ b/ProjectTracker.Admin/Pages/Users/Edit.cshtml.cs
@@ -58,6 +58,9 @@ namespace ProjectTracker.Admin.Pages.Users
             [Display(Name = "Two-Factor Authentication")]
             public bool TwoFactorEnabled { get; set; }
 
+            [Display(Name = "Kullanıcı Aktif mi?")]
+            public bool IsActive { get; set; }
+
             [Display(Name = "Account Locked")]
             public bool IsLocked { get; set; }
 
@@ -90,6 +93,7 @@ namespace ProjectTracker.Admin.Pages.Users
                 PhoneNumber = user.PhoneNumber,
                 EmailConfirmed = user.EmailConfirmed,
                 TwoFactorEnabled = user.TwoFactorEnabled,
+                IsActive = user.IsActive,
                 IsLocked = user.LockoutEnd.HasValue && user.LockoutEnd > DateTimeOffset.Now,
                 LockoutEnd = user.LockoutEnd
             };
@@ -130,6 +134,7 @@ namespace ProjectTracker.Admin.Pages.Users
             user.PhoneNumber = Input.PhoneNumber;
             user.EmailConfirmed = Input.EmailConfirmed;
             user.TwoFactorEnabled = Input.TwoFactorEnabled;
+            user.IsActive = Input.IsActive;
 
             // Handle lockout
             if (Input.IsLocked && (!user.LockoutEnd.HasValue || user.LockoutEnd <= DateTimeOffset.Now))

--- a/ProjectTracker.Core/Entities/ApplicationUser.cs
+++ b/ProjectTracker.Core/Entities/ApplicationUser.cs
@@ -11,6 +11,8 @@ namespace ProjectTracker.Core.Entities
         public DateTime CreatedDate { get; set; }
         public DateTime? LastLoginDate { get; set; }
 
+        public bool IsActive { get; set; } = true;
+
         public bool Kvkk { get; set; }
         public DateTime? KvkkTimestamp { get; set; }
 

--- a/ProjectTracker.Data/Context/AppDbContext.cs
+++ b/ProjectTracker.Data/Context/AppDbContext.cs
@@ -342,6 +342,9 @@ namespace ProjectTracker.Data.Context
                     .IsRequired()
                     .HasMaxLength(100);
 
+                entity.Property(e => e.IsActive)
+                    .HasDefaultValue(true);
+
                 // User-Employee ilişkisi (One-to-One)
                 entity.HasOne(u => u.Employee)
                     .WithOne()

--- a/ProjectTracker.Data/Migrations/20250806143837_AddIsActiveToApplicationUser.Designer.cs
+++ b/ProjectTracker.Data/Migrations/20250806143837_AddIsActiveToApplicationUser.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ProjectTracker.Data.Context;
 
@@ -11,9 +12,11 @@ using ProjectTracker.Data.Context;
 namespace ProjectTracker.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250806143837_AddIsActiveToApplicationUser")]
+    partial class AddIsActiveToApplicationUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ProjectTracker.Data/Migrations/20250806143837_AddIsActiveToApplicationUser.cs
+++ b/ProjectTracker.Data/Migrations/20250806143837_AddIsActiveToApplicationUser.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsActiveToApplicationUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsActive",
+                table: "AspNetUsers",
+                type: "bit",
+                nullable: false,
+                defaultValue: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsActive",
+                table: "AspNetUsers");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add IsActive field to ApplicationUser with default true
- allow admins to toggle account activation on Edit User page
- update EF Core schema to store IsActive

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689367bd52d4832bb7ecea99dc57342e