### PR TITLE
Add basic dashboards with service and localization

### DIFF
--- a/ProjectTracker.Admin/Pages/Dashboard/Index.cshtml
+++ b/ProjectTracker.Admin/Pages/Dashboard/Index.cshtml
@@ -1,0 +1,19 @@
+@page
+@model ProjectTracker.Admin.Pages.Dashboard.IndexModel
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer L
+
+<h2>@L["Projects"]</h2>
+<div class="row">
+@foreach (var proj in Model.Projects)
+{
+    <div class="col-md-4">
+        <div class="card mb-3">
+            <div class="card-body">
+                <h5 class="card-title">@proj.Name</h5>
+                <p class="card-text">@proj.Description</p>
+                <a asp-page="Project" asp-route-projectId="@proj.Id" class="btn btn-primary">@L["ViewDashboard"]</a>
+            </div>
+        </div>
+    </div>
+}
+</div>

--- a/ProjectTracker.Admin/Pages/Dashboard/Index.cshtml.cs
+++ b/ProjectTracker.Admin/Pages/Dashboard/Index.cshtml.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using ProjectTracker.Service.Services.Interfaces;
+using ProjectTracker.Service.DTOs;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ProjectTracker.Admin.Pages.Dashboard
+{
+    [Authorize(Roles = "Admin,Manager")]
+    public class IndexModel : PageModel
+    {
+        private readonly IProjectService _projectService;
+        public IEnumerable<ProjectDto> Projects { get; set; } = Enumerable.Empty<ProjectDto>();
+
+        public IndexModel(IProjectService projectService)
+        {
+            _projectService = projectService;
+        }
+
+        public async Task OnGetAsync()
+        {
+            Projects = await _projectService.GetAllProjectsAsync();
+        }
+    }
+}

--- a/ProjectTracker.Admin/Pages/Dashboard/Project.cshtml
+++ b/ProjectTracker.Admin/Pages/Dashboard/Project.cshtml
@@ -1,0 +1,52 @@
+@page
+@model ProjectTracker.Admin.Pages.Dashboard.ProjectModel
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer L
+
+<h2>@L["ProjectDashboard"]</h2>
+
+<div class="row mb-3">
+    <div class="col-md-3">
+        <div class="card text-bg-light">
+            <div class="card-body">
+                <h5 class="card-title">@Model.Dashboard.Summary?.Name</h5>
+                <p class="card-text">@L["Budget"]: @Model.Dashboard.Summary?.Budget</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<canvas id="worklogChart"></canvas>
+
+<table id="maintenanceTable" class="table table-striped"></table>
+
+<div class="mt-3">
+    <a asp-route-fmt="xlsx" asp-page-handler="Export" asp-route-projectId="@Model.ProjectId" class="btn btn-outline-success">Excel</a>
+    <a asp-route-fmt="pdf" asp-page-handler="Export" asp-route-projectId="@Model.ProjectId" class="btn btn-outline-danger">PDF</a>
+</div>
+
+@section Scripts{
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/2.3.6/js/dataTables.buttons.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/2.3.6/js/buttons.html5.min.js"></script>
+    <script>
+        const data = @Json.Serialize(Model.Dashboard.WorkLogTrend);
+        new Chart(document.getElementById('worklogChart'), {
+            type: 'line',
+            data: {
+                labels: data.map(x => x.month),
+                datasets: [{ label: 'Hours', data: data.map(x => x.hours) }]
+            }
+        });
+        new DataTable('#maintenanceTable', {
+            data: @Json.Serialize(Model.Dashboard.UpcomingMaintenance),
+            columns: [
+                { title: 'Equipment', data: 'equipment' },
+                { title: 'NextDate', data: 'nextDate' },
+                { title: 'Type', data: 'type' }
+            ],
+            dom: 'Bfrtip',
+            buttons: ['copy', 'excel', 'pdf']
+        });
+    </script>
+}

--- a/ProjectTracker.Admin/Pages/Dashboard/Project.cshtml.cs
+++ b/ProjectTracker.Admin/Pages/Dashboard/Project.cshtml.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using ProjectTracker.Service.Services.Interfaces;
+using ProjectTracker.Service.Enums;
+using System.Threading.Tasks;
+
+namespace ProjectTracker.Admin.Pages.Dashboard
+{
+    [Authorize(Roles = "Admin,Manager")]
+    public class ProjectModel : PageModel
+    {
+        private readonly IProjectDashboardService _dashboardService;
+
+        public ProjectDashboardViewModel Dashboard { get; set; } = new();
+        public int ProjectId { get; set; }
+
+        public ProjectModel(IProjectDashboardService dashboardService)
+        {
+            _dashboardService = dashboardService;
+        }
+
+        public async Task OnGetAsync(int projectId)
+        {
+            ProjectId = projectId;
+            Dashboard = new ProjectDashboardViewModel
+            {
+                ProjectId = projectId,
+                Summary = await _dashboardService.GetSummaryAsync(projectId),
+                TaskStatuses = await _dashboardService.GetTaskStatusAsync(projectId),
+                WorkLogTrend = await _dashboardService.GetWorkLogTrendAsync(projectId, 12),
+                UpcomingMaintenance = await _dashboardService.GetUpcomingMaintenanceAsync(projectId, 30)
+            };
+        }
+
+        public async Task<IActionResult> OnGetExportAsync(string fmt, int projectId)
+        {
+            var format = fmt.Equals("pdf", StringComparison.OrdinalIgnoreCase) ? ExportFormat.Pdf : ExportFormat.Excel;
+            var bytes = await _dashboardService.ExportAsync(ExportTarget.WorkLogs, format, projectId);
+            var ext = format == ExportFormat.Excel ? "xlsx" : "pdf";
+            var mime = format == ExportFormat.Excel ?
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" :
+                "application/pdf";
+            return File(bytes, mime, $"export_{System.DateTime.Now:yyyyMMdd}.{ext}");
+        }
+    }
+}

--- a/ProjectTracker.Admin/Pages/Dashboard/ProjectDashboardViewModel.cs
+++ b/ProjectTracker.Admin/Pages/Dashboard/ProjectDashboardViewModel.cs
@@ -1,0 +1,14 @@
+using ProjectTracker.Service.DTOs;
+using System.Collections.Generic;
+
+namespace ProjectTracker.Admin.Pages.Dashboard
+{
+    public class ProjectDashboardViewModel
+    {
+        public ProjectSummaryDto Summary { get; set; }
+        public IEnumerable<TaskStatusDto> TaskStatuses { get; set; } = System.Linq.Enumerable.Empty<TaskStatusDto>();
+        public IEnumerable<WorkLogTrendDto> WorkLogTrend { get; set; } = System.Linq.Enumerable.Empty<WorkLogTrendDto>();
+        public IEnumerable<MaintenanceDto> UpcomingMaintenance { get; set; } = System.Linq.Enumerable.Empty<MaintenanceDto>();
+        public int ProjectId { get; set; }
+    }
+}

--- a/ProjectTracker.Admin/Resources/Pages/Dashboard/Index.en.resx
+++ b/ProjectTracker.Admin/Resources/Pages/Dashboard/Index.en.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Projects" xml:space="preserve">
+    <value>Projects</value>
+  </data>
+  <data name="ViewDashboard" xml:space="preserve">
+    <value>View Dashboard</value>
+  </data>
+</root>

--- a/ProjectTracker.Admin/Resources/Pages/Dashboard/Index.tr.resx
+++ b/ProjectTracker.Admin/Resources/Pages/Dashboard/Index.tr.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Projects" xml:space="preserve">
+    <value>Projeler</value>
+  </data>
+  <data name="ViewDashboard" xml:space="preserve">
+    <value>Göster</value>
+  </data>
+</root>

--- a/ProjectTracker.Admin/Resources/Pages/Dashboard/Project.en.resx
+++ b/ProjectTracker.Admin/Resources/Pages/Dashboard/Project.en.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="ProjectDashboard" xml:space="preserve">
+    <value>Project Dashboard</value>
+  </data>
+  <data name="Budget" xml:space="preserve">
+    <value>Budget</value>
+  </data>
+</root>

--- a/ProjectTracker.Admin/Resources/Pages/Dashboard/Project.tr.resx
+++ b/ProjectTracker.Admin/Resources/Pages/Dashboard/Project.tr.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="ProjectDashboard" xml:space="preserve">
+    <value>Proje Paneli</value>
+  </data>
+  <data name="Budget" xml:space="preserve">
+    <value>Bütçe</value>
+  </data>
+</root>

--- a/ProjectTracker.Service/DTOs/MaintenanceDto.cs
+++ b/ProjectTracker.Service/DTOs/MaintenanceDto.cs
@@ -1,0 +1,10 @@
+namespace ProjectTracker.Service.DTOs
+{
+    public class MaintenanceDto
+    {
+        public string Equipment { get; set; }
+        public System.DateTime NextDate { get; set; }
+        public string Type { get; set; }
+        public string Project { get; set; }
+    }
+}

--- a/ProjectTracker.Service/DTOs/ProjectSummaryDto.cs
+++ b/ProjectTracker.Service/DTOs/ProjectSummaryDto.cs
@@ -1,0 +1,12 @@
+namespace ProjectTracker.Service.DTOs
+{
+    public class ProjectSummaryDto
+    {
+        public string Name { get; set; }
+        public decimal Budget { get; set; }
+        public decimal Spent { get; set; }
+        public decimal HoursMonth { get; set; }
+        public decimal HoursTotal { get; set; }
+        public int ActiveEmployeeCount { get; set; }
+    }
+}

--- a/ProjectTracker.Service/DTOs/TaskStatusDto.cs
+++ b/ProjectTracker.Service/DTOs/TaskStatusDto.cs
@@ -1,0 +1,8 @@
+namespace ProjectTracker.Service.DTOs
+{
+    public class TaskStatusDto
+    {
+        public string Status { get; set; }
+        public int Count { get; set; }
+    }
+}

--- a/ProjectTracker.Service/DTOs/WorkLogTrendDto.cs
+++ b/ProjectTracker.Service/DTOs/WorkLogTrendDto.cs
@@ -1,0 +1,8 @@
+namespace ProjectTracker.Service.DTOs
+{
+    public class WorkLogTrendDto
+    {
+        public string Month { get; set; }
+        public decimal Hours { get; set; }
+    }
+}

--- a/ProjectTracker.Service/Enums/ExportEnums.cs
+++ b/ProjectTracker.Service/Enums/ExportEnums.cs
@@ -1,0 +1,16 @@
+namespace ProjectTracker.Service.Enums
+{
+    public enum ExportTarget
+    {
+        Projects,
+        WorkLogs,
+        Tasks,
+        Maintenance
+    }
+
+    public enum ExportFormat
+    {
+        Excel,
+        Pdf
+    }
+}

--- a/ProjectTracker.Service/Implementations/ProjectDashboardService.cs
+++ b/ProjectTracker.Service/Implementations/ProjectDashboardService.cs
@@ -1,0 +1,39 @@
+using ProjectTracker.Service.DTOs;
+using ProjectTracker.Service.Enums;
+using ProjectTracker.Service.Services.Interfaces;
+
+namespace ProjectTracker.Service.Implementations
+{
+    public class ProjectDashboardService : IProjectDashboardService
+    {
+        public Task<ProjectSummaryDto> GetSummaryAsync(int projectId)
+        {
+            var dto = new ProjectSummaryDto();
+            return Task.FromResult(dto);
+        }
+
+        public Task<IEnumerable<TaskStatusDto>> GetTaskStatusAsync(int projectId)
+        {
+            IEnumerable<TaskStatusDto> list = new List<TaskStatusDto>();
+            return Task.FromResult(list);
+        }
+
+        public Task<IEnumerable<WorkLogTrendDto>> GetWorkLogTrendAsync(int projectId, int months)
+        {
+            IEnumerable<WorkLogTrendDto> list = new List<WorkLogTrendDto>();
+            return Task.FromResult(list);
+        }
+
+        public Task<IEnumerable<MaintenanceDto>> GetUpcomingMaintenanceAsync(int projectId, int days)
+        {
+            IEnumerable<MaintenanceDto> list = new List<MaintenanceDto>();
+            return Task.FromResult(list);
+        }
+
+        public Task<byte[]> ExportAsync(ExportTarget target, ExportFormat fmt, int? projectId)
+        {
+            byte[] bytes = System.Array.Empty<byte>();
+            return Task.FromResult(bytes);
+        }
+    }
+}

--- a/ProjectTracker.Service/Interfaces/IProjectDashboardService.cs
+++ b/ProjectTracker.Service/Interfaces/IProjectDashboardService.cs
@@ -1,0 +1,16 @@
+using ProjectTracker.Service.DTOs;
+using ProjectTracker.Service.Enums;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ProjectTracker.Service.Services.Interfaces
+{
+    public interface IProjectDashboardService
+    {
+        Task<ProjectSummaryDto> GetSummaryAsync(int projectId);
+        Task<IEnumerable<TaskStatusDto>> GetTaskStatusAsync(int projectId);
+        Task<IEnumerable<WorkLogTrendDto>> GetWorkLogTrendAsync(int projectId, int months);
+        Task<IEnumerable<MaintenanceDto>> GetUpcomingMaintenanceAsync(int projectId, int days);
+        Task<byte[]> ExportAsync(ExportTarget target, ExportFormat fmt, int? projectId);
+    }
+}

--- a/ProjectTracker.Service/ProjectTracker.Service.csproj
+++ b/ProjectTracker.Service/ProjectTracker.Service.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="ClosedXML" Version="0.103.0" />
+    <PackageReference Include="QuestPDF" Version="2023.10.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ProjectTracker.Web/Areas/Dashboard/Controllers/DashboardController.cs
+++ b/ProjectTracker.Web/Areas/Dashboard/Controllers/DashboardController.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using ProjectTracker.Service.Services.Interfaces;
+
+namespace ProjectTracker.Web.Areas.Dashboard.Controllers
+{
+    [Area("Dashboard")]
+    [Authorize(Roles = "Admin,Manager")]
+    public class DashboardController : Controller
+    {
+        private readonly IProjectService _projectService;
+
+        public DashboardController(IProjectService projectService)
+        {
+            _projectService = projectService;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            var projects = await _projectService.GetAllProjectsAsync();
+            return View(projects);
+        }
+    }
+}

--- a/ProjectTracker.Web/Areas/Dashboard/Controllers/ProjectController.cs
+++ b/ProjectTracker.Web/Areas/Dashboard/Controllers/ProjectController.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using ProjectTracker.Service.Services.Interfaces;
+using ProjectTracker.Web.ViewModels;
+using ProjectTracker.Service.Enums;
+
+namespace ProjectTracker.Web.Areas.Dashboard.Controllers
+{
+    [Area("Dashboard")]
+    [Authorize(Roles = "Admin,Manager")]
+    public class ProjectController : Controller
+    {
+        private readonly IProjectDashboardService _dashboardService;
+
+        public ProjectController(IProjectDashboardService dashboardService)
+        {
+            _dashboardService = dashboardService;
+        }
+
+        public async Task<IActionResult> Index(int projectId)
+        {
+            var vm = new ProjectDashboardViewModel
+            {
+                ProjectId = projectId,
+                Summary = await _dashboardService.GetSummaryAsync(projectId),
+                TaskStatuses = await _dashboardService.GetTaskStatusAsync(projectId),
+                WorkLogTrend = await _dashboardService.GetWorkLogTrendAsync(projectId, 12),
+                UpcomingMaintenance = await _dashboardService.GetUpcomingMaintenanceAsync(projectId, 30)
+            };
+            return View(vm);
+        }
+
+        public async Task<IActionResult> Export(ExportFormat fmt, ExportTarget target, int? projectId)
+        {
+            var bytes = await _dashboardService.ExportAsync(target, fmt, projectId);
+            var ext = fmt == ExportFormat.Excel ? "xlsx" : "pdf";
+            var mime = fmt == ExportFormat.Excel ?
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" :
+                "application/pdf";
+            return File(bytes, mime, $"export_{System.DateTime.Now:yyyyMMdd}.{ext}");
+        }
+    }
+}

--- a/ProjectTracker.Web/Areas/Dashboard/Views/Dashboard/Index.cshtml
+++ b/ProjectTracker.Web/Areas/Dashboard/Views/Dashboard/Index.cshtml
@@ -1,0 +1,18 @@
+@model IEnumerable<ProjectTracker.Service.DTOs.ProjectDto>
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer L
+
+<h2>@L["Projects"]</h2>
+<div class="row">
+@foreach (var proj in Model)
+{
+    <div class="col-md-4">
+        <div class="card mb-3">
+            <div class="card-body">
+                <h5 class="card-title">@proj.Name</h5>
+                <p class="card-text">@proj.Description</p>
+                <a asp-area="Dashboard" asp-controller="Project" asp-action="Index" asp-route-projectId="@proj.Id" class="btn btn-primary">@L["ViewDashboard"]</a>
+            </div>
+        </div>
+    </div>
+}
+</div>

--- a/ProjectTracker.Web/Areas/Dashboard/Views/Project/Index.cshtml
+++ b/ProjectTracker.Web/Areas/Dashboard/Views/Project/Index.cshtml
@@ -1,0 +1,51 @@
+@model ProjectTracker.Web.ViewModels.ProjectDashboardViewModel
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer L
+
+<h2>@L["ProjectDashboard"]</h2>
+
+<div class="row mb-3">
+    <div class="col-md-3">
+        <div class="card text-bg-light">
+            <div class="card-body">
+                <h5 class="card-title">@Model.Summary?.Name</h5>
+                <p class="card-text">@L["Budget"]: @Model.Summary?.Budget</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<canvas id="worklogChart"></canvas>
+
+<table id="maintenanceTable" class="table table-striped"></table>
+
+<div class="mt-3">
+    <a asp-action="Export" asp-route-fmt="Excel" asp-route-target="WorkLogs" asp-route-projectId="@Model.ProjectId" class="btn btn-outline-success">Excel</a>
+    <a asp-action="Export" asp-route-fmt="Pdf" asp-route-target="WorkLogs" asp-route-projectId="@Model.ProjectId" class="btn btn-outline-danger">PDF</a>
+</div>
+
+@section Scripts{
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/2.3.6/js/dataTables.buttons.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/2.3.6/js/buttons.html5.min.js"></script>
+    <script>
+        const data = @Json.Serialize(Model.WorkLogTrend);
+        new Chart(document.getElementById('worklogChart'), {
+            type: 'line',
+            data: {
+                labels: data.map(x => x.month),
+                datasets: [{ label: 'Hours', data: data.map(x => x.hours) }]
+            }
+        });
+        new DataTable('#maintenanceTable', {
+            data: @Json.Serialize(Model.UpcomingMaintenance),
+            columns: [
+                { title: 'Equipment', data: 'equipment' },
+                { title: 'NextDate', data: 'nextDate' },
+                { title: 'Type', data: 'type' }
+            ],
+            dom: 'Bfrtip',
+            buttons: ['copy', 'excel', 'pdf']
+        });
+    </script>
+}

--- a/ProjectTracker.Web/Areas/Dashboard/Views/_ViewImports.cshtml
+++ b/ProjectTracker.Web/Areas/Dashboard/Views/_ViewImports.cshtml
@@ -1,0 +1,4 @@
+@using ProjectTracker.Web
+@using ProjectTracker.Web.ViewModels
+@using ProjectTracker.Service.DTOs
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/ProjectTracker.Web/Program.cs
+++ b/ProjectTracker.Web/Program.cs
@@ -119,6 +119,7 @@ builder.Services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
 builder.Services.AddScoped<IProjectService, ProjectService>();
 builder.Services.AddScoped<IWorkLogService, WorkLogService>();
 builder.Services.AddScoped<IEmployeeService, EmployeeService>();
+builder.Services.AddScoped<IProjectDashboardService, ProjectDashboardService>();
 
 builder.Services.AddScoped<IAuthorizationHandler, WorkLogAuthorizationHandler>();
 

--- a/ProjectTracker.Web/Resources/Areas/Dashboard/Index.en.resx
+++ b/ProjectTracker.Web/Resources/Areas/Dashboard/Index.en.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Projects" xml:space="preserve">
+    <value>Projects</value>
+  </data>
+  <data name="ViewDashboard" xml:space="preserve">
+    <value>View Dashboard</value>
+  </data>
+</root>

--- a/ProjectTracker.Web/Resources/Areas/Dashboard/Index.tr.resx
+++ b/ProjectTracker.Web/Resources/Areas/Dashboard/Index.tr.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Projects" xml:space="preserve">
+    <value>Projeler</value>
+  </data>
+  <data name="ViewDashboard" xml:space="preserve">
+    <value>Göster</value>
+  </data>
+</root>

--- a/ProjectTracker.Web/Resources/Areas/Dashboard/Project.en.resx
+++ b/ProjectTracker.Web/Resources/Areas/Dashboard/Project.en.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="ProjectDashboard" xml:space="preserve">
+    <value>Project Dashboard</value>
+  </data>
+  <data name="Budget" xml:space="preserve">
+    <value>Budget</value>
+  </data>
+</root>

--- a/ProjectTracker.Web/Resources/Areas/Dashboard/Project.tr.resx
+++ b/ProjectTracker.Web/Resources/Areas/Dashboard/Project.tr.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="ProjectDashboard" xml:space="preserve">
+    <value>Proje Paneli</value>
+  </data>
+  <data name="Budget" xml:space="preserve">
+    <value>Bütçe</value>
+  </data>
+</root>

--- a/ProjectTracker.Web/ViewModels/ProjectDashboardViewModel.cs
+++ b/ProjectTracker.Web/ViewModels/ProjectDashboardViewModel.cs
@@ -1,0 +1,14 @@
+using ProjectTracker.Service.DTOs;
+using System.Collections.Generic;
+
+namespace ProjectTracker.Web.ViewModels
+{
+    public class ProjectDashboardViewModel
+    {
+        public ProjectSummaryDto Summary { get; set; }
+        public IEnumerable<TaskStatusDto> TaskStatuses { get; set; } = System.Linq.Enumerable.Empty<TaskStatusDto>();
+        public IEnumerable<WorkLogTrendDto> WorkLogTrend { get; set; } = System.Linq.Enumerable.Empty<WorkLogTrendDto>();
+        public IEnumerable<MaintenanceDto> UpcomingMaintenance { get; set; } = System.Linq.Enumerable.Empty<MaintenanceDto>();
+        public int ProjectId { get; set; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # ProjectTracker
+
+## Dashboard Setup
+
+After cloning the repository run the database migrations:
+
+```bash
+dotnet ef database update
+```
+
+The dashboard views rely on CDN hosted versions of Chart.js and DataTables
+with the Buttons extension.  No additional installation is required.
+
+Seeded roles include `Admin`, `Manager` and `Employee`.  Ensure the seeding
+step runs on first start to create these roles and default users.


### PR DESCRIPTION
## Summary
- scaffold project dashboard service and DTOs
- add MVC and Razor Pages dashboards with export stubs
- wire up localization resources and sample charts/tables

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689463afaa98832b8a5a995800ee309d