### PR TITLE
Add bilingual localization and culture tests

### DIFF
--- a/ProjectTracker.Web/Areas/Dashboard/Views/Project/Index.cshtml
+++ b/ProjectTracker.Web/Areas/Dashboard/Views/Project/Index.cshtml
@@ -37,6 +37,7 @@
                 datasets: [{ label: 'Hours', data: data.map(x => x.hours) }]
             }
         });
+        const culture = document.documentElement.lang.startsWith('tr') ? 'tr' : 'en';
         new DataTable('#maintenanceTable', {
             data: @Json.Serialize(Model.UpcomingMaintenance),
             columns: [
@@ -45,7 +46,8 @@
                 { title: 'Type', data: 'type' }
             ],
             dom: 'Bfrtip',
-            buttons: ['copy', 'excel', 'pdf']
+            buttons: ['copy', 'excel', 'pdf'],
+            language: { url: `/js/localization/datatables_${culture}.json` }
         });
     </script>
 }

--- a/ProjectTracker.Web/Controllers/CultureController.cs
+++ b/ProjectTracker.Web/Controllers/CultureController.cs
@@ -7,7 +7,7 @@ namespace ProjectTracker.Web.Controllers
     [AllowAnonymous]
     public class CultureController : Controller
     {
-        [HttpPost]
+        [HttpGet]
         public IActionResult Set(string culture, string returnUrl)
         {
             Response.Cookies.Append(

--- a/ProjectTracker.Web/Program.cs
+++ b/ProjectTracker.Web/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Localization;
+using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.Extensions.Options;
 using System.Globalization;
 using ProjectTracker.Core.Entities;
@@ -39,7 +40,7 @@ builder.Services.Configure<RequestLocalizationOptions>(options =>
 });
 
 builder.Services.AddControllersWithViews()
-       .AddViewLocalization()
+       .AddViewLocalization(LanguageViewLocationExpanderFormat.SubFolder)
        .AddDataAnnotationsLocalization();
 
 // DbContext
@@ -194,3 +195,5 @@ app.MapControllerRoute(
     pattern: "{controller=Home}/{action=Index}/{id?}");
 
 app.Run();
+
+public partial class Program { }

--- a/ProjectTracker.Web/Resources/DataAnnotations.en-US.resx
+++ b/ProjectTracker.Web/Resources/DataAnnotations.en-US.resx
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Required" xml:space="preserve">
+    <value>This field is required</value>
+  </data>
+</root>

--- a/ProjectTracker.Web/Resources/DataAnnotations.tr-TR.resx
+++ b/ProjectTracker.Web/Resources/DataAnnotations.tr-TR.resx
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Required" xml:space="preserve">
+    <value>Bu alan zorunlu</value>
+  </data>
+</root>

--- a/ProjectTracker.Web/Resources/SharedResource.en-US.resx
+++ b/ProjectTracker.Web/Resources/SharedResource.en-US.resx
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="AppName" xml:space="preserve">
+    <value>ProjectTracker</value>
+  </data>
+</root>

--- a/ProjectTracker.Web/Resources/SharedResource.resx
+++ b/ProjectTracker.Web/Resources/SharedResource.resx
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="AppName" xml:space="preserve">
+    <value>ProjectTracker</value>
+  </data>
+</root>

--- a/ProjectTracker.Web/Resources/SharedResource.tr-TR.resx
+++ b/ProjectTracker.Web/Resources/SharedResource.tr-TR.resx
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="AppName" xml:space="preserve">
+    <value>ProjectTracker</value>
+  </data>
+</root>

--- a/ProjectTracker.Web/Resources/Views/Shared/_Layout.en-US.resx
+++ b/ProjectTracker.Web/Resources/Views/Shared/_Layout.en-US.resx
@@ -3,6 +3,9 @@
   <data name="Language" xml:space="preserve">
     <value>Language</value>
   </data>
+  <data name="AppName" xml:space="preserve">
+    <value>ProjectTracker</value>
+  </data>
   <data name="Logout" xml:space="preserve">
     <value>Logout</value>
   </data>

--- a/ProjectTracker.Web/Resources/Views/Shared/_Layout.tr-TR.resx
+++ b/ProjectTracker.Web/Resources/Views/Shared/_Layout.tr-TR.resx
@@ -3,6 +3,9 @@
   <data name="Language" xml:space="preserve">
     <value>Dil</value>
   </data>
+  <data name="AppName" xml:space="preserve">
+    <value>ProjectTracker</value>
+  </data>
   <data name="Logout" xml:space="preserve">
     <value>Çıkış Yap</value>
   </data>

--- a/ProjectTracker.Web/ViewModels/ChangePasswordViewModel.cs
+++ b/ProjectTracker.Web/ViewModels/ChangePasswordViewModel.cs
@@ -4,12 +4,12 @@ namespace ProjectTracker.Web.ViewModels
 {
     public class ChangePasswordViewModel
     {
-        [Required(ErrorMessage = "Mevcut şifre zorunludur")]
+        [Required(ErrorMessage = "Required")]
         [DataType(DataType.Password)]
         [Display(Name = "Mevcut Şifre")]
         public string OldPassword { get; set; }
 
-        [Required(ErrorMessage = "Yeni şifre zorunludur")]
+        [Required(ErrorMessage = "Required")]
         [StringLength(100, ErrorMessage = "{0} en az {2} ve en fazla {1} karakter olmalıdır.", MinimumLength = 6)]
         [DataType(DataType.Password)]
         [Display(Name = "Yeni Şifre")]

--- a/ProjectTracker.Web/ViewModels/CreateWorkLogViewModel.cs
+++ b/ProjectTracker.Web/ViewModels/CreateWorkLogViewModel.cs
@@ -5,28 +5,28 @@ namespace ProjectTracker.Web.ViewModels
 {
     public class CreateWorkLogViewModel
     {
-        [Required(ErrorMessage = "Başlık zorunludur")]
+        [Required(ErrorMessage = "Required")]
         [Display(Name = "Başlık")]
         public string Title { get; set; } = string.Empty;
 
         [Display(Name = "Açıklama")]
         public string Description { get; set; } = string.Empty;
 
-        [Required(ErrorMessage = "Çalışma tarihi zorunludur")]
+        [Required(ErrorMessage = "Required")]
         [Display(Name = "Çalışma Tarihi")]
         [DataType(DataType.Date)]
         public DateTime WorkDate { get; set; } = DateTime.Today;
 
-        [Required(ErrorMessage = "Harcanan süre zorunludur")]
+        [Required(ErrorMessage = "Required")]
         [Display(Name = "Harcanan Süre (Saat)")]
         [Range(0.1, 24, ErrorMessage = "Süre 0.1 ile 24 saat arasında olmalıdır")]
         public decimal HoursSpent { get; set; }
 
-        [Required(ErrorMessage = "Proje seçimi zorunludur")]
+        [Required(ErrorMessage = "Required")]
         [Display(Name = "Proje")]
         public int ProjectId { get; set; }
 
-        [Required(ErrorMessage = "Çalışan seçimi zorunludur")]
+        [Required(ErrorMessage = "Required")]
         [Display(Name = "Çalışan")]
         public int EmployeeId { get; set; }
 

--- a/ProjectTracker.Web/ViewModels/LoginViewModel.cs
+++ b/ProjectTracker.Web/ViewModels/LoginViewModel.cs
@@ -4,12 +4,12 @@ namespace ProjectTracker.Web.ViewModels
 {
     public class LoginViewModel
     {
-        [Required(ErrorMessage = "Email adresi zorunludur")]
+        [Required(ErrorMessage = "Required")]
         [EmailAddress(ErrorMessage = "Geçerli bir email adresi giriniz")]
         [Display(Name = "Email")]
         public string Email { get; set; }
 
-        [Required(ErrorMessage = "Şifre zorunludur")]
+        [Required(ErrorMessage = "Required")]
         [DataType(DataType.Password)]
         [Display(Name = "Şifre")]
         public string Password { get; set; }

--- a/ProjectTracker.Web/ViewModels/LoginWith2faViewModel.cs
+++ b/ProjectTracker.Web/ViewModels/LoginWith2faViewModel.cs
@@ -4,7 +4,7 @@ namespace ProjectTracker.Web.ViewModels
 {
     public class LoginWith2faViewModel
     {
-        [Required(ErrorMessage = "Doğrulama kodu zorunludur")]
+        [Required(ErrorMessage = "Required")]
         [StringLength(7, ErrorMessage = "{0} {2} ile {1} karakter arasında olmalıdır.", MinimumLength = 6)]
         [DataType(DataType.Text)]
         [Display(Name = "Doğrulama Kodu")]

--- a/ProjectTracker.Web/ViewModels/RegisterViewModel.cs
+++ b/ProjectTracker.Web/ViewModels/RegisterViewModel.cs
@@ -5,20 +5,20 @@ namespace ProjectTracker.Web.ViewModels
 {
     public class RegisterViewModel
     {
-        [Required(ErrorMessageResourceName = "FirstNameRequired", ErrorMessageResourceType = typeof(User))]
+        [Required(ErrorMessage = "Required")]
         [Display(Name = "FirstName", ResourceType = typeof(User))]
         public string FirstName { get; set; }
 
-        [Required(ErrorMessageResourceName = "LastNameRequired", ErrorMessageResourceType = typeof(User))]
+        [Required(ErrorMessage = "Required")]
         [Display(Name = "LastName", ResourceType = typeof(User))]
         public string LastName { get; set; }
 
-        [Required(ErrorMessageResourceName = "EmailRequired", ErrorMessageResourceType = typeof(User))]
+        [Required(ErrorMessage = "Required")]
         [EmailAddress(ErrorMessageResourceName = "EmailInvalid", ErrorMessageResourceType = typeof(User))]
         [Display(Name = "Email", ResourceType = typeof(User))]
         public string Email { get; set; }
 
-        [Required(ErrorMessageResourceName = "PasswordRequired", ErrorMessageResourceType = typeof(User))]
+        [Required(ErrorMessage = "Required")]
         [StringLength(100, ErrorMessageResourceName = "PasswordLength", ErrorMessageResourceType = typeof(User), MinimumLength = 6)]
         [DataType(DataType.Password)]
         [Display(Name = "Password", ResourceType = typeof(User))]

--- a/ProjectTracker.Web/Views/Home/Index.cshtml
+++ b/ProjectTracker.Web/Views/Home/Index.cshtml
@@ -1,7 +1,7 @@
 @model ProjectTracker.Web.ViewModels.DashboardViewModel
-@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer L
 @{
-    ViewData["Title"] = Localizer["Home"];
+    ViewData["Title"] = L["Home"];
 }
 
 <div class="container-fluid">
@@ -9,18 +9,18 @@
         <div class="col-12">
             @if (User.Identity?.IsAuthenticated ?? false)
             {
-                <h2>@Localizer["WelcomeUser", User.Identity!.Name ?? string.Empty]</h2>
-                <p class="text-muted">@Localizer["LastLogin"] @DateTime.Now.ToString("dd MMMM yyyy HH:mm")</p>
+                <h2>@L["WelcomeUser", User.Identity!.Name ?? string.Empty]</h2>
+                <p class="text-muted">@L["LastLogin"] @DateTime.Now.ToString("dd MMMM yyyy HH:mm")</p>
             }
             else
             {
                 <div class="jumbotron">
-                    <h1 class="display-4">@Localizer["WelcomeTitle"]</h1>
-                    <p class="lead">@Localizer["WelcomeLead"]</p>
+                    <h1 class="display-4">@L["WelcomeTitle"]</h1>
+                    <p class="lead">@L["WelcomeLead"]</p>
                     <hr class="my-4">
-                    <p>@Localizer["WelcomeBody"]</p>
+                    <p>@L["WelcomeBody"]</p>
                     <a asp-controller="Account" asp-action="Login" class="btn btn-primary btn-lg">
-                        <i class="fas fa-sign-in-alt"></i> @Localizer["Login"]
+                        <i class="fas fa-sign-in-alt"></i> @L["Login"]
                     </a>
                 </div>
             }
@@ -38,7 +38,7 @@
                         <div class="row no-gutters align-items-center">
                             <div class="col mr-2">
                                 <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">
-                                    @Localizer["TotalProjects"]
+                                    @L["TotalProjects"]
                                 </div>
                                 <div class="h5 mb-0 font-weight-bold text-gray-800">@Model.TotalProjects</div>
                             </div>
@@ -61,7 +61,7 @@
                     <div class="card shadow">
                         <div class="card-header">
                             <h5 class="mb-0">
-                                <i class="fas fa-clock"></i> @Localizer["RecentWorkLogs"]
+                                <i class="fas fa-clock"></i> @L["RecentWorkLogs"]
                             </h5>
                         </div>
                         <div class="card-body">
@@ -69,12 +69,12 @@
                                 <table class="table table-hover">
                                     <thead>
                                         <tr>
-                                            <th>@Localizer["Project"]</th>
-                                            <th>@Localizer["Employee"]</th>
-                                            <th>@Localizer["Title"]</th>
-                                            <th>@Localizer["Date"]</th>
-                                            <th>@Localizer["Duration"]</th>
-                                            <th>@Localizer["Action"]</th>
+                                            <th>@L["Project"]</th>
+                                            <th>@L["Employee"]</th>
+                                            <th>@L["Title"]</th>
+                                            <th>@L["Date"]</th>
+                                            <th>@L["Duration"]</th>
+                                            <th>@L["Action"]</th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -85,7 +85,7 @@
                                                 <td>@log.EmployeeName</td>
                                                 <td>@log.Title</td>
                                                 <td>@log.WorkDate.ToString("dd.MM.yyyy")</td>
-                                                <td>@log.HoursSpent @Localizer["Hours"]</td>
+                                                <td>@log.HoursSpent @L["Hours"]</td>
                                                 <td>
                                                     <a asp-controller="WorkLog" asp-action="Details" asp-route-id="@log.Id"
                                                        class="btn btn-sm btn-info">

--- a/ProjectTracker.Web/Views/Shared/_CultureSwitcher.cshtml
+++ b/ProjectTracker.Web/Views/Shared/_CultureSwitcher.cshtml
@@ -4,7 +4,7 @@
 @{
     var culture = Thread.CurrentThread.CurrentUICulture.Name;
 }
-<form asp-controller="Culture" asp-action="Set" method="post" class="d-inline">
+<form asp-controller="Culture" asp-action="Set" method="get" class="d-inline">
     <select name="culture" onchange="this.form.submit()" class="form-select form-select-sm w-auto">
         @foreach (var c in loc.Value.SupportedUICultures)
         {
@@ -18,5 +18,5 @@
             }
         }
     </select>
-    <input type="hidden" name="returnUrl" value="@Context.Request.Path" />
+    <input type="hidden" name="returnUrl" value="@(Context.Request.Path + Context.Request.QueryString)" />
 </form>

--- a/ProjectTracker.Web/Views/Shared/_Layout.cshtml
+++ b/ProjectTracker.Web/Views/Shared/_Layout.cshtml
@@ -1,13 +1,17 @@
 ﻿@using Microsoft.Extensions.Configuration
 @using System.Globalization
+@using System.Collections.Generic
 @inject IConfiguration Configuration
-@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer L
+@{
+    ViewBag.JsTexts ??= new Dictionary<string, string>();
+}
 <!DOCTYPE html>
 <html lang="@CultureInfo.CurrentUICulture.Name">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>@ViewData["Title"] - ProjectTracker</title>
+    <title>@L["AppName"] - @ViewData["Title"]</title>
 
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
@@ -31,7 +35,7 @@
                     <!-- Ana Sayfa (Home) -->
                     <li class="nav-item">
                         <a class="nav-link" asp-controller="Home" asp-action="Index">
-                            <i class="fas fa-home"></i> @Localizer["Home"]
+                            <i class="fas fa-home"></i> @L["Home"]
                         </a>
                     </li>
 
@@ -40,14 +44,14 @@
                         <!-- Kontrol Paneli (Dashboard) -->
                         <li class="nav-item">
                             <a class="nav-link" asp-controller="UserDashboard" asp-action="Index">
-                                <i class="fas fa-tachometer-alt"></i> @Localizer["Dashboard"]
+                                <i class="fas fa-tachometer-alt"></i> @L["Dashboard"]
                             </a>
                         </li>
 
                         <!-- Profilim (My Profile) -->
                         <li class="nav-item">
                             <a class="nav-link" asp-controller="Account" asp-action="Profile">
-                                <i class="fas fa-user"></i> @Localizer["Profile"]
+                                <i class="fas fa-user"></i> @L["Profile"]
                             </a>
                         </li>
 
@@ -56,7 +60,7 @@
                         {
                             <li class="nav-item">
                                 <a class="nav-link" asp-controller="WorkLog" asp-action="MyWorkLog">
-                                    <i class="fas fa-clock"></i> @Localizer["MyWorkLogs"]
+                                    <i class="fas fa-clock"></i> @L["MyWorkLogs"]
                                 </a>
                             </li>
                         }
@@ -66,22 +70,22 @@
                         {
                             <li class="nav-item dropdown">
                                 <a class="nav-link dropdown-toggle" href="#" id="managementDropdown" role="button" data-bs-toggle="dropdown">
-                                    <i class="fas fa-briefcase"></i> @Localizer["Management"]
+                                    <i class="fas fa-briefcase"></i> @L["Management"]
                                 </a>
                                 <ul class="dropdown-menu">
                                     <li>
                                         <a class="dropdown-item" asp-controller="Project" asp-action="Index">
-                                            <i class="fas fa-project-diagram"></i> @Localizer["Projects"]
+                                            <i class="fas fa-project-diagram"></i> @L["Projects"]
                                         </a>
                                     </li>
                                     <li>
                                         <a class="dropdown-item" asp-controller="Employee" asp-action="Index">
-                                            <i class="fas fa-users"></i> @Localizer["Employees"]
+                                            <i class="fas fa-users"></i> @L["Employees"]
                                         </a>
                                     </li>
                                     <li>
                                         <a class="dropdown-item" asp-controller="WorkLog" asp-action="Index">
-                                            <i class="fas fa-tasks"></i> @Localizer["AllWorkLogs"]
+                                            <i class="fas fa-tasks"></i> @L["AllWorkLogs"]
                                         </a>
                                     </li>
                                 </ul>
@@ -93,17 +97,17 @@
                         {
                             <li class="nav-item dropdown">
                                 <a class="nav-link dropdown-toggle" href="#" id="systemDropdown" role="button" data-bs-toggle="dropdown">
-                                    <i class="fas fa-cog"></i> @Localizer["System"]
+                                    <i class="fas fa-cog"></i> @L["System"]
                                 </a>
                                 <ul class="dropdown-menu">
                                     <li>
                                         <a class="dropdown-item" href="@Configuration["AdminPanelUrl"]" target="_blank">
-                                            <i class="fas fa-user-shield"></i> @Localizer["AdminPanel"]
+                                            <i class="fas fa-user-shield"></i> @L["AdminPanel"]
                                         </a>
                                     </li>
                                     <li>
                                         <a class="dropdown-item" asp-controller="System" asp-action="Settings">
-                                            <i class="fas fa-sliders-h"></i> @Localizer["SystemSettings"]
+                                            <i class="fas fa-sliders-h"></i> @L["SystemSettings"]
                                         </a>
                                     </li>
                                 </ul>
@@ -115,7 +119,7 @@
                 <!-- Right side - User info and logout -->
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item d-flex align-items-center me-2">
-                        <span class="text-white me-1">@Localizer["Language"]:</span>
+                        <span class="text-white me-1">@L["Language"]:</span>
                         @await Html.PartialAsync("_CultureSwitcher")
                     </li>
                     @if (User.Identity?.IsAuthenticated ?? false)
@@ -124,15 +128,15 @@
                         <li class="nav-item d-flex align-items-center me-2">
                             @if (User.IsInRole("Admin"))
                             {
-                                <span class="badge bg-danger">@Localizer["Admin"]</span>
+                                <span class="badge bg-danger">@L["Admin"]</span>
                             }
                             else if (User.IsInRole("Manager"))
                             {
-                                <span class="badge bg-warning">@Localizer["Manager"]</span>
+                                <span class="badge bg-warning">@L["Manager"]</span>
                             }
                             else if (User.IsInRole("Employee"))
                             {
-                                <span class="badge bg-info">@Localizer["Employee"]</span>
+                                <span class="badge bg-info">@L["Employee"]</span>
                             }
                         </li>
 
@@ -144,19 +148,19 @@
                             <ul class="dropdown-menu dropdown-menu-end">
                                 <li>
                                     <a class="dropdown-item" asp-controller="Account" asp-action="Profile">
-                                        <i class="fas fa-user"></i> @Localizer["Profile"]
+                                        <i class="fas fa-user"></i> @L["Profile"]
                                     </a>
                                 </li>
                                 <li>
                                     <a class="dropdown-item" asp-controller="Account" asp-action="ChangePassword">
-                                        <i class="fas fa-key"></i> @Localizer["ChangePassword"]
+                                        <i class="fas fa-key"></i> @L["ChangePassword"]
                                     </a>
                                 </li>
                                 <li><hr class="dropdown-divider"></li>
                                 <li>
                                     <form asp-controller="Account" asp-action="Logout" method="post" class="d-inline">
                                         <button type="submit" class="dropdown-item">
-                                            <i class="fas fa-sign-out-alt"></i> @Localizer["Logout"]
+                                            <i class="fas fa-sign-out-alt"></i> @L["Logout"]
                                         </button>
                                     </form>
                                 </li>
@@ -167,7 +171,7 @@
                     {
                         <li class="nav-item">
                             <a class="nav-link" asp-controller="Account" asp-action="Login">
-                                <i class="fas fa-sign-in-alt"></i> @Localizer["Login"]
+                                <i class="fas fa-sign-in-alt"></i> @L["Login"]
                             </a>
                         </li>
                     }
@@ -186,15 +190,18 @@
     <!-- Footer -->
     <footer class="footer mt-auto py-3 bg-light">
         <div class="container">
-            <span class="text-muted">&copy; 2024 - ProjectTracker - <a asp-controller="Home" asp-action="Privacy">@Localizer["Privacy"]</a></span>
+            <span class="text-muted">&copy; 2024 - ProjectTracker - <a asp-controller="Home" asp-action="Privacy">@L["Privacy"]</a></span>
         </div>
     </footer>
 
     <!-- Scripts -->
-    <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="~/js/site.js" asp-append-version="true"></script>
+      <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+      <script src="~/js/site.js" asp-append-version="true"></script>
+      <script>
+          window.t = key => JSON.parse('@Html.Raw(Json.Serialize(ViewBag.JsTexts))')[key];
+      </script>
 
-    @await RenderSectionAsync("Scripts", required: false)
-</body>
+      @await RenderSectionAsync("Scripts", required: false)
+  </body>
 </html>

--- a/ProjectTracker.Web/wwwroot/js/localization/datatables_en.json
+++ b/ProjectTracker.Web/wwwroot/js/localization/datatables_en.json
@@ -1,0 +1,12 @@
+{
+  "decimal": "",
+  "emptyTable": "No data available in table",
+  "info": "Showing _START_ to _END_ of _TOTAL_ entries",
+  "infoEmpty": "Showing 0 to 0 of 0 entries",
+  "infoFiltered": "(filtered from _MAX_ total entries)",
+  "lengthMenu": "Show _MENU_ entries",
+  "loadingRecords": "Loading...",
+  "processing": "Processing...",
+  "search": "Search:",
+  "zeroRecords": "No matching records found"
+}

--- a/ProjectTracker.Web/wwwroot/js/localization/datatables_tr.json
+++ b/ProjectTracker.Web/wwwroot/js/localization/datatables_tr.json
@@ -1,0 +1,12 @@
+{
+  "decimal": "",
+  "emptyTable": "Tabloda veri yok",
+  "info": "_TOTAL_ kayıttan _START_ - _END_ arası gösteriliyor",
+  "infoEmpty": "0 kayıttan 0 - 0 arası gösteriliyor",
+  "infoFiltered": "(_MAX_ kayıt içerisinden filtrelendi)",
+  "lengthMenu": "Sayfada _MENU_ kayıt göster",
+  "loadingRecords": "Yükleniyor...",
+  "processing": "İşleniyor...",
+  "search": "Ara:",
+  "zeroRecords": "Eşleşen kayıt bulunamadı"
+}

--- a/tests/ProjectTracker.Tests/CultureMiddlewareTests.cs
+++ b/tests/ProjectTracker.Tests/CultureMiddlewareTests.cs
@@ -1,0 +1,30 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using ProjectTracker.Web;
+using Xunit;
+
+namespace ProjectTracker.Tests
+{
+    public class CultureMiddlewareTests : IClassFixture<WebApplicationFactory<Program>>
+    {
+        private readonly WebApplicationFactory<Program> _factory;
+
+        public CultureMiddlewareTests(WebApplicationFactory<Program> factory)
+        {
+            _factory = factory;
+        }
+
+        [Fact]
+        public async Task AcceptLanguageHeader_SetsUiCulture()
+        {
+            var client = _factory.CreateClient();
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Add("Accept-Language", "en-US");
+            var response = await client.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+            var html = await response.Content.ReadAsStringAsync();
+            Assert.Contains("<html lang=\"en-US\"", html);
+        }
+    }
+}

--- a/tests/ProjectTracker.Tests/ProjectTracker.Tests.csproj
+++ b/tests/ProjectTracker.Tests/ProjectTracker.Tests.csproj
@@ -11,6 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\ProjectTracker.Core\ProjectTracker.Core.csproj" />


### PR DESCRIPTION
## Summary
- configure localization for `tr-TR` and `en-US` views and data annotations
- add culture switcher with cookie + query support
- translate validation and DataTables resources with JS helpers
- cover culture middleware with integration test

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68946926563c832bb3f5e83d99926aa6