### PR TITLE
Use service counts for home dashboard

### DIFF
--- a/ProjectTracker.Service/Services/Implementations/EmployeeService.cs
+++ b/ProjectTracker.Service/Services/Implementations/EmployeeService.cs
@@ -121,5 +121,10 @@ namespace ProjectTracker.Service.Services.Implementations
 
             return dto;
         }
+
+        public Task<int> GetEmployeeCountAsync()
+        {
+            return _employeeRepository.CountAsync();
+        }
     }
 }

--- a/ProjectTracker.Service/Services/Implementations/MaintenanceScheduleService.cs
+++ b/ProjectTracker.Service/Services/Implementations/MaintenanceScheduleService.cs
@@ -55,5 +55,11 @@ namespace ProjectTracker.Service.Services.Implementations
                 await _context.SaveChangesAsync();
             }
         }
+
+        public async Task<int> GetUpcomingMaintenanceCountAsync()
+        {
+            var today = DateTime.Today;
+            return await _context.MaintenanceSchedules.CountAsync(m => m.NextMaintenanceDate > today);
+        }
     }
 }

--- a/ProjectTracker.Service/Services/Implementations/WorkLogService.cs
+++ b/ProjectTracker.Service/Services/Implementations/WorkLogService.cs
@@ -244,5 +244,10 @@ namespace ProjectTracker.Service.Services.Implementations
 
             return _mapper.Map<IEnumerable<WorkLogDto>>(workLogs.Take(count));
         }
+
+        public Task<int> GetActiveWorkLogCountAsync()
+        {
+            return _workLogRepository.CountAsync();
+        }
     }
 }

--- a/ProjectTracker.Service/Services/Interfaces/IEmployeeService.cs
+++ b/ProjectTracker.Service/Services/Interfaces/IEmployeeService.cs
@@ -14,5 +14,6 @@ namespace ProjectTracker.Service.Services.Interfaces
         Task<bool> DeleteEmployeeAsync(int id);
         Task<bool> EmployeeExistsAsync(int id);
         Task<EmployeeDto> GetEmployeeByEmailAsync(string email);
+        Task<int> GetEmployeeCountAsync();
     }
 }

--- a/ProjectTracker.Service/Services/Interfaces/IMaintenanceScheduleService.cs
+++ b/ProjectTracker.Service/Services/Interfaces/IMaintenanceScheduleService.cs
@@ -1,4 +1,6 @@
 using ProjectTracker.Service.DTOs;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace ProjectTracker.Service.Services.Interfaces
 {
@@ -8,5 +10,6 @@ namespace ProjectTracker.Service.Services.Interfaces
         Task<IEnumerable<MaintenanceScheduleDto>> GetDueAsync();
         Task AddAsync(MaintenanceScheduleDto dto);
         Task MarkNotifiedAsync(int id);
+        Task<int> GetUpcomingMaintenanceCountAsync();
     }
 }

--- a/ProjectTracker.Service/Services/Interfaces/IWorkLogService.cs
+++ b/ProjectTracker.Service/Services/Interfaces/IWorkLogService.cs
@@ -17,5 +17,6 @@ namespace ProjectTracker.Service.Services.Interfaces
         Task<WorkLogDto> UpdateWorkLogAsync(int id, WorkLogDto workLogDto, int userId);
         Task<bool> DeleteWorkLogAsync(int id, int userId);
         Task<IEnumerable<WorkLogDto>> GetRecentWorkLogsAsync(int count = 10);
+        Task<int> GetActiveWorkLogCountAsync();
     }
 }

--- a/ProjectTracker.Web/Controllers/HomeController.cs
+++ b/ProjectTracker.Web/Controllers/HomeController.cs
@@ -12,18 +12,24 @@ namespace ProjectTracker.Web.Controllers
         private readonly ILogger<HomeController> _logger;
         private readonly IProjectService _projectService;
         private readonly IWorkLogService _workLogService;
+        private readonly IEmployeeService _employeeService;
+        private readonly IMaintenanceScheduleService _maintenanceScheduleService;
 
         public HomeController(
             ILogger<HomeController> logger,
             IProjectService projectService,
-            IWorkLogService workLogService)
+            IWorkLogService workLogService,
+            IEmployeeService employeeService,
+            IMaintenanceScheduleService maintenanceScheduleService)
         {
             _logger = logger;
             _projectService = projectService;
             _workLogService = workLogService;
+            _employeeService = employeeService;
+            _maintenanceScheduleService = maintenanceScheduleService;
         }
 
-        [AllowAnonymous] // Ana sayfa herkese açýk
+        [AllowAnonymous] // Ana sayfa herkese aÃ§Ä±k
         public async Task<IActionResult> Index()
         {
             if (User.Identity?.IsAuthenticated ?? false)
@@ -31,10 +37,10 @@ namespace ProjectTracker.Web.Controllers
                 var viewModel = new DashboardViewModel
                 {
                     TotalProjects = await _projectService.GetProjectCountAsync(),
-                    TotalEmployees = 8,
-                    ActiveWorkLogs = 24,  // This is now int, not List
-                    UpcomingMaintenances = 3,  // This is now int, not List
-                    RecentWorkLogs = (await _workLogService.GetRecentWorkLogsAsync(5)).ToList()  // Add .ToList()
+                    TotalEmployees = await _employeeService.GetEmployeeCountAsync(),
+                    ActiveWorkLogs = await _workLogService.GetActiveWorkLogCountAsync(),
+                    UpcomingMaintenances = await _maintenanceScheduleService.GetUpcomingMaintenanceCountAsync(),
+                    RecentWorkLogs = (await _workLogService.GetRecentWorkLogsAsync(5)).ToList()
                 };
 
                 return View(viewModel);
@@ -43,7 +49,7 @@ namespace ProjectTracker.Web.Controllers
             return View();
         }
 
-        // Privacy giriþ gerektiriyor (global policy'den)
+        // Privacy giriÅŸ gerektiriyor (global policy'den)
         public IActionResult Privacy()
         {
             return View();

--- a/ProjectTracker.Web/Program.cs
+++ b/ProjectTracker.Web/Program.cs
@@ -127,6 +127,7 @@ builder.Services.AddScoped<IProjectService, ProjectService>();
 builder.Services.AddScoped<IWorkLogService, WorkLogService>();
 builder.Services.AddScoped<IEmployeeService, EmployeeService>();
 builder.Services.AddScoped<IProjectDashboardService, ProjectDashboardService>();
+builder.Services.AddScoped<IMaintenanceScheduleService, MaintenanceScheduleService>();
 
 builder.Services.AddScoped<IAuthorizationHandler, WorkLogAuthorizationHandler>();
 


### PR DESCRIPTION
## Summary
- add count methods to employee, work log, and maintenance services
- inject services into HomeController and load dashboard counts asynchronously
- register maintenance schedule service for dependency injection

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689484323114832ba2400d78bd198b8c