### PR TITLE
Add integration tests for web and admin

### DIFF
--- a/ProjectTracker.Admin/AssemblyMarker.cs
+++ b/ProjectTracker.Admin/AssemblyMarker.cs
@@ -1,0 +1,2 @@
+namespace ProjectTracker.Admin;
+public class AdminAssemblyMarker { }

--- a/ProjectTracker.Admin/Program.cs
+++ b/ProjectTracker.Admin/Program.cs
@@ -158,3 +158,5 @@ app.UseAuthentication();
 app.UseAuthorization();
 app.MapRazorPages();
 app.Run();
+
+public partial class Program { }

--- a/ProjectTracker.Web/AssemblyMarker.cs
+++ b/ProjectTracker.Web/AssemblyMarker.cs
@@ -1,0 +1,2 @@
+namespace ProjectTracker.Web;
+public class WebAssemblyMarker { }

--- a/tests/ProjectTracker.Tests/AdminPagesTests.cs
+++ b/tests/ProjectTracker.Tests/AdminPagesTests.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+using AdminMarker = ProjectTracker.Admin.AdminAssemblyMarker;
+
+namespace ProjectTracker.Tests;
+
+public class AdminPagesTests : IClassFixture<CustomWebApplicationFactory<AdminMarker>>
+{
+    private readonly HttpClient _client;
+
+    public AdminPagesTests(CustomWebApplicationFactory<AdminMarker> factory)
+    {
+        _client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+    }
+
+    [Fact]
+    public async Task Index_RedirectsToLogin()
+    {
+        var response = await _client.GetAsync("/");
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.Contains("/Identity/Account/Login", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Dashboard_RedirectsToLogin()
+    {
+        var response = await _client.GetAsync("/Dashboard");
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.Contains("/Identity/Account/Login", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Projects_RedirectsToLogin()
+    {
+        var response = await _client.GetAsync("/Projects");
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.Contains("/Identity/Account/Login", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Users_RedirectsToLogin()
+    {
+        var response = await _client.GetAsync("/Users");
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.Contains("/Identity/Account/Login", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Tasks_RedirectsToLogin()
+    {
+        var response = await _client.GetAsync("/Tasks");
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.Contains("/Identity/Account/Login", response.Headers.Location?.OriginalString);
+    }
+}

--- a/tests/ProjectTracker.Tests/CultureMiddlewareTests.cs
+++ b/tests/ProjectTracker.Tests/CultureMiddlewareTests.cs
@@ -1,16 +1,16 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Testing;
-using ProjectTracker.Web;
 using Xunit;
+using WebMarker = ProjectTracker.Web.WebAssemblyMarker;
 
 namespace ProjectTracker.Tests
 {
-    public class CultureMiddlewareTests : IClassFixture<WebApplicationFactory<Program>>
+    public class CultureMiddlewareTests : IClassFixture<CustomWebApplicationFactory<WebMarker>>
     {
-        private readonly WebApplicationFactory<Program> _factory;
+        private readonly CustomWebApplicationFactory<WebMarker> _factory;
 
-        public CultureMiddlewareTests(WebApplicationFactory<Program> factory)
+        public CultureMiddlewareTests(CustomWebApplicationFactory<WebMarker> factory)
         {
             _factory = factory;
         }

--- a/tests/ProjectTracker.Tests/CustomWebApplicationFactory.cs
+++ b/tests/ProjectTracker.Tests/CustomWebApplicationFactory.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using ProjectTracker.Data.Context;
+
+public class CustomWebApplicationFactory<TProgram> : WebApplicationFactory<TProgram> where TProgram : class
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<AppDbContext>));
+            if (descriptor != null)
+            {
+                services.Remove(descriptor);
+            }
+
+            services.AddDbContext<AppDbContext>(options =>
+            {
+                options.UseInMemoryDatabase($"InMemoryDbForTesting_{Guid.NewGuid()}");
+            });
+        });
+    }
+}

--- a/tests/ProjectTracker.Tests/ProjectTracker.Tests.csproj
+++ b/tests/ProjectTracker.Tests/ProjectTracker.Tests.csproj
@@ -18,5 +18,6 @@
     <ProjectReference Include="..\..\ProjectTracker.Data\ProjectTracker.Data.csproj" />
     <ProjectReference Include="..\..\ProjectTracker.Service\ProjectTracker.Service.csproj" />
     <ProjectReference Include="..\..\ProjectTracker.Web\ProjectTracker.Web.csproj" />
+    <ProjectReference Include="..\..\ProjectTracker.Admin\ProjectTracker.Admin.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/ProjectTracker.Tests/WebPagesTests.cs
+++ b/tests/ProjectTracker.Tests/WebPagesTests.cs
@@ -1,0 +1,59 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+using WebMarker = ProjectTracker.Web.WebAssemblyMarker;
+
+namespace ProjectTracker.Tests;
+
+public class WebPagesTests : IClassFixture<CustomWebApplicationFactory<WebMarker>>
+{
+    private readonly HttpClient _client;
+
+    public WebPagesTests(CustomWebApplicationFactory<WebMarker> factory)
+    {
+        _client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+    }
+
+    [Fact]
+    public async Task HomePage_ReturnsSuccess()
+    {
+        var response = await _client.GetAsync("/");
+        response.EnsureSuccessStatusCode();
+    }
+
+    [Fact]
+    public async Task PrivacyPage_RedirectsToLogin()
+    {
+        var response = await _client.GetAsync("/Home/Privacy");
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.Contains("/Account/Login", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task LoginPage_ReturnsSuccess()
+    {
+        var response = await _client.GetAsync("/Account/Login");
+        response.EnsureSuccessStatusCode();
+    }
+
+    [Fact]
+    public async Task WorkLog_Index_RedirectsToLogin()
+    {
+        var response = await _client.GetAsync("/WorkLog");
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.Contains("/Account/Login", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task NonExistingPage_RedirectsToLogin()
+    {
+        var response = await _client.GetAsync("/does-not-exist");
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.Contains("/Account/Login", response.Headers.Location?.OriginalString);
+    }
+}


### PR DESCRIPTION
## Summary
- add assembly markers and partial Program to support integration testing
- create custom web application factory using in-memory database
- add 10 integration tests covering admin and web page access

## Testing
- `dotnet test tests/ProjectTracker.Tests/ProjectTracker.Tests.csproj --no-build -l "console;verbosity=minimal"`

------
https://chatgpt.com/codex/tasks/task_e_689487fe778c832ba715ad95e4690d67