### PR TITLE
Localize maintenance table headers

### DIFF
--- a/ProjectTracker.Web/Areas/Dashboard/Views/Project/Index.cshtml
+++ b/ProjectTracker.Web/Areas/Dashboard/Views/Project/Index.cshtml
@@ -1,5 +1,10 @@
 @model ProjectTracker.Web.ViewModels.ProjectDashboardViewModel
 @inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer L
+@{
+    ViewBag.JsTexts["Equipment"] = L["Equipment"].Value;
+    ViewBag.JsTexts["NextDate"] = L["NextDate"].Value;
+    ViewBag.JsTexts["Type"] = L["Type"].Value;
+}
 
 <h2>@L["ProjectDashboard"]</h2>
 
@@ -41,9 +46,9 @@
         new DataTable('#maintenanceTable', {
             data: @Json.Serialize(Model.UpcomingMaintenance),
             columns: [
-                { title: 'Equipment', data: 'equipment' },
-                { title: 'NextDate', data: 'nextDate' },
-                { title: 'Type', data: 'type' }
+                { title: t('Equipment'), data: 'equipment' },
+                { title: t('NextDate'), data: 'nextDate' },
+                { title: t('Type'), data: 'type' }
             ],
             dom: 'Bfrtip',
             buttons: ['copy', 'excel', 'pdf'],

--- a/ProjectTracker.Web/Resources/Areas/Dashboard/Project.en.resx
+++ b/ProjectTracker.Web/Resources/Areas/Dashboard/Project.en.resx
@@ -6,4 +6,13 @@
   <data name="Budget" xml:space="preserve">
     <value>Budget</value>
   </data>
+  <data name="Equipment" xml:space="preserve">
+    <value>Equipment</value>
+  </data>
+  <data name="NextDate" xml:space="preserve">
+    <value>Next Date</value>
+  </data>
+  <data name="Type" xml:space="preserve">
+    <value>Type</value>
+  </data>
 </root>

--- a/ProjectTracker.Web/Resources/Areas/Dashboard/Project.tr.resx
+++ b/ProjectTracker.Web/Resources/Areas/Dashboard/Project.tr.resx
@@ -6,4 +6,13 @@
   <data name="Budget" xml:space="preserve">
     <value>Bütçe</value>
   </data>
+  <data name="Equipment" xml:space="preserve">
+    <value>Ekipman</value>
+  </data>
+  <data name="NextDate" xml:space="preserve">
+    <value>Sonraki Tarih</value>
+  </data>
+  <data name="Type" xml:space="preserve">
+    <value>Tip</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary
- expose localized strings for maintenance table headers through `ViewBag.JsTexts`
- read localized titles via `t()` during DataTable initialization
- add resource keys for Equipment, Next Date and Type

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689487a0b33c832bba20dbc272a6ca9c