### PR TITLE
feat: expand dashboard statistics

### DIFF
--- a/ProjectTracker.Service/DTOs/DashboardDto.cs
+++ b/ProjectTracker.Service/DTOs/DashboardDto.cs
@@ -18,6 +18,10 @@ namespace ProjectTracker.Service.DTOs
         public int TotalProjects { get; set; }
         public int ActiveProjects { get; set; }
         public int CompletedProjects { get; set; }
+        public int PendingWorkLogApprovals { get; set; }
+        public int ActiveTasks { get; set; }
+        public int CompletedTasks { get; set; }
+        public int TotalEquipment { get; set; }
         public decimal TotalHoursThisMonth { get; set; }
         public decimal TotalHoursThisWeek { get; set; }
         public int TotalWorkLogs { get; set; }

--- a/ProjectTracker.Service/Services/Implementations/UserDashboardService.cs
+++ b/ProjectTracker.Service/Services/Implementations/UserDashboardService.cs
@@ -18,6 +18,8 @@ namespace ProjectTracker.Service.Services.Implementations
         private readonly IRepository<WorkLog> _workLogRepository;
         private readonly IRepository<Project> _projectRepository;
         private readonly IRepository<ProjectEmployee> _projectEmployeeRepository;
+        private readonly IRepository<MaintenanceLog> _maintenanceLogRepository;
+        private readonly IRepository<Equipment> _equipmentRepository;
         private readonly IMapper _mapper;
 
         public UserDashboardService(
@@ -25,12 +27,16 @@ namespace ProjectTracker.Service.Services.Implementations
             IRepository<WorkLog> workLogRepository,
             IRepository<Project> projectRepository,
             IRepository<ProjectEmployee> projectEmployeeRepository,
+            IRepository<MaintenanceLog> maintenanceLogRepository,
+            IRepository<Equipment> equipmentRepository,
             IMapper mapper)
         {
             _employeeRepository = employeeRepository;
             _workLogRepository = workLogRepository;
             _projectRepository = projectRepository;
             _projectEmployeeRepository = projectEmployeeRepository;
+            _maintenanceLogRepository = maintenanceLogRepository;
+            _equipmentRepository = equipmentRepository;
             _mapper = mapper;
         }
 
@@ -47,6 +53,10 @@ namespace ProjectTracker.Service.Services.Implementations
                     TotalProjects = 0,
                     ActiveProjects = 0,
                     CompletedProjects = 0,
+                    PendingWorkLogApprovals = 0,
+                    ActiveTasks = 0,
+                    CompletedTasks = 0,
+                    TotalEquipment = 0,
                     TotalHoursThisMonth = 0,
                     TotalHoursThisWeek = 0,
                     TotalWorkLogs = 0
@@ -102,9 +112,17 @@ namespace ProjectTracker.Service.Services.Implementations
                 stats.ActiveProjects = projectEmployees.Count(pe => pe.Project.Status == ProjectStatus.Active);
                 stats.CompletedProjects = projectEmployees.Count(pe => pe.Project.Status == ProjectStatus.Completed);
 
+                var projectIds = projectEmployees.Select(pe => pe.ProjectId).ToList();
+
+                // Equipment count across user's projects
+                stats.TotalEquipment = await _equipmentRepository.CountAsync(e => e.ProjectId.HasValue && projectIds.Contains(e.ProjectId.Value));
+
                 // Get work logs stats
-                var workLogs = await _workLogRepository.GetAsync(w => w.EmployeeId == employee.Id);
+                var workLogs = await _workLogRepository.GetAsync(
+                    w => w.EmployeeId == employee.Id,
+                    includes: new Expression<Func<WorkLog, object>>[] { w => w.History });
                 stats.TotalWorkLogs = workLogs.Count();
+                stats.PendingWorkLogApprovals = workLogs.Count(w => !w.History.Any(h => h.Action == "Approved"));
 
                 // This month's hours
                 var startOfMonth = new DateTime(DateTime.Now.Year, DateTime.Now.Month, 1);
@@ -117,6 +135,13 @@ namespace ProjectTracker.Service.Services.Implementations
                 stats.TotalHoursThisWeek = workLogs
                     .Where(w => w.WorkDate >= startOfWeek)
                     .Sum(w => w.HoursSpent);
+
+                // Maintenance tasks for user's projects
+                var maintenanceLogs = await _maintenanceLogRepository.GetAsync(
+                    l => l.MaintenanceSchedule.Project.ProjectEmployees.Any(pe => pe.EmployeeId == employee.Id),
+                    includes: new Expression<Func<MaintenanceLog, object>>[] { l => l.MaintenanceSchedule });
+                stats.ActiveTasks = maintenanceLogs.Count(l => !l.IsCompleted);
+                stats.CompletedTasks = maintenanceLogs.Count(l => l.IsCompleted);
             }
 
             return stats;

--- a/ProjectTracker.Web/Resources/Views/UserDashboard/Index.en-US.resx
+++ b/ProjectTracker.Web/Resources/Views/UserDashboard/Index.en-US.resx
@@ -21,6 +21,13 @@
   <data name="RequestLeave" xml:space="preserve"><value>Request Leave</value></data>
   <data name="CreateProject" xml:space="preserve"><value>Create Project</value></data>
   <data name="TotalProjects" xml:space="preserve"><value>Total Projects</value></data>
+  <data name="ActiveProjects" xml:space="preserve"><value>Active Projects</value></data>
+  <data name="CompletedProjects" xml:space="preserve"><value>Completed Projects</value></data>
+  <data name="PendingWorkLogApprovals" xml:space="preserve"><value>Pending Work Log Approvals</value></data>
+  <data name="ActiveTasks" xml:space="preserve"><value>Active Tasks</value></data>
+  <data name="CompletedTasks" xml:space="preserve"><value>Completed Tasks</value></data>
+  <data name="TotalEquipment" xml:space="preserve"><value>Total Equipment</value></data>
+  <data name="TotalWorkLogs" xml:space="preserve"><value>Total Work Logs</value></data>
   <data name="ProjectTimeCost" xml:space="preserve"><value>Project Time and Cost</value></data>
   <data name="Project" xml:space="preserve"><value>Project</value></data>
   <data name="TotalHours" xml:space="preserve"><value>Total Hours</value></data>

--- a/ProjectTracker.Web/Resources/Views/UserDashboard/Index.tr-TR.resx
+++ b/ProjectTracker.Web/Resources/Views/UserDashboard/Index.tr-TR.resx
@@ -21,6 +21,13 @@
   <data name="RequestLeave" xml:space="preserve"><value>İzin Talep Et</value></data>
   <data name="CreateProject" xml:space="preserve"><value>Proje Oluştur</value></data>
   <data name="TotalProjects" xml:space="preserve"><value>Toplam Proje</value></data>
+  <data name="ActiveProjects" xml:space="preserve"><value>Aktif Projeler</value></data>
+  <data name="CompletedProjects" xml:space="preserve"><value>Tamamlanan Projeler</value></data>
+  <data name="PendingWorkLogApprovals" xml:space="preserve"><value>Onay Bekleyen İş Kayıtları</value></data>
+  <data name="ActiveTasks" xml:space="preserve"><value>Aktif Görevler</value></data>
+  <data name="CompletedTasks" xml:space="preserve"><value>Tamamlanan Görevler</value></data>
+  <data name="TotalEquipment" xml:space="preserve"><value>Toplam Ekipman</value></data>
+  <data name="TotalWorkLogs" xml:space="preserve"><value>Toplam İş Kayıtları</value></data>
   <data name="ProjectTimeCost" xml:space="preserve"><value>Proje Süre ve Maliyet</value></data>
   <data name="Project" xml:space="preserve"><value>Proje</value></data>
   <data name="TotalHours" xml:space="preserve"><value>Toplam Saat</value></data>

--- a/ProjectTracker.Web/Views/UserDashboard/Index.cshtml
+++ b/ProjectTracker.Web/Views/UserDashboard/Index.cshtml
@@ -141,11 +141,67 @@
 </div>
 
 <div class="row mt-4">
-    <div class="col-md-4">
-        <div class="card">
+    <div class="col-sm-6 col-md-4 col-lg-3 mb-3">
+        <div class="card h-100">
             <div class="card-body">
                 <h5 class="card-title">@L["TotalProjects"]</h5>
-                <p class="card-text display-4">@Model.Stats.TotalProjects</p>
+                <p class="card-text display-6">@Model.Stats.TotalProjects</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-md-4 col-lg-3 mb-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5 class="card-title">@L["ActiveProjects"]</h5>
+                <p class="card-text display-6">@Model.Stats.ActiveProjects</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-md-4 col-lg-3 mb-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5 class="card-title">@L["CompletedProjects"]</h5>
+                <p class="card-text display-6">@Model.Stats.CompletedProjects</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-md-4 col-lg-3 mb-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5 class="card-title">@L["PendingWorkLogApprovals"]</h5>
+                <p class="card-text display-6">@Model.Stats.PendingWorkLogApprovals</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-md-4 col-lg-3 mb-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5 class="card-title">@L["ActiveTasks"]</h5>
+                <p class="card-text display-6">@Model.Stats.ActiveTasks</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-md-4 col-lg-3 mb-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5 class="card-title">@L["CompletedTasks"]</h5>
+                <p class="card-text display-6">@Model.Stats.CompletedTasks</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-md-4 col-lg-3 mb-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5 class="card-title">@L["TotalEquipment"]</h5>
+                <p class="card-text display-6">@Model.Stats.TotalEquipment</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-md-4 col-lg-3 mb-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5 class="card-title">@L["TotalWorkLogs"]</h5>
+                <p class="card-text display-6">@Model.Stats.TotalWorkLogs</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- extend dashboard statistics DTO to track tasks, equipment, and pending approvals
- compute new statistics via repository queries in `UserDashboardService`
- display all stats in responsive cards on user dashboard

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68949bf76a48832b80a1cc954eb431a8