### PR TITLE
Handle empty dashboard collections and show empty-state messages

### DIFF
--- a/ProjectTracker.Web/Controllers/UserDashboardController.cs
+++ b/ProjectTracker.Web/Controllers/UserDashboardController.cs
@@ -5,6 +5,7 @@ using ProjectTracker.Service.DTOs;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace ProjectTracker.Web.Controllers
 {
@@ -31,6 +32,11 @@ namespace ProjectTracker.Web.Controllers
 
             // Get dashboard data
             var dashboardData = await _userDashboardService.GetDashboardDataAsync(userId);
+
+            // Ensure collections are not null
+            dashboardData.ActiveProjects ??= new List<ProjectDto>();
+            dashboardData.RecentWorkLogs ??= new List<WorkLogDto>();
+            dashboardData.ProjectReports ??= new List<ProjectReportDto>();
 
             // Set user info
             dashboardData.UserName = userName;

--- a/ProjectTracker.Web/Views/UserDashboard/Index.cshtml
+++ b/ProjectTracker.Web/Views/UserDashboard/Index.cshtml
@@ -57,7 +57,7 @@
 </div>
 
 <!-- Active Projects Widget -->
-@if (Model.ActiveProjects != null && Model.ActiveProjects.Any())
+@if (Model.ActiveProjects.Any())
 {
     <div class="row mb-4">
         <div class="col-12">
@@ -90,6 +90,10 @@
             </div>
         </div>
     </div>
+}
+else
+{
+    <div class="text-muted">No data available</div>
 }
 
 <!-- Work Log Summary Widget -->
@@ -151,7 +155,7 @@
     </div>
 </div>
 
-@if (Model.ProjectReports != null && Model.ProjectReports.Any())
+@if (Model.ProjectReports.Any())
 {
     var labelsJson = System.Text.Json.JsonSerializer.Serialize(Model.ProjectReports.Select(p => p.ProjectName));
     var budgetJson = System.Text.Json.JsonSerializer.Serialize(Model.ProjectReports.Select(p => p.Budget));
@@ -210,8 +214,12 @@
         });
     </script>
 }
+else
+{
+    <div class="text-muted">No data available</div>
+}
 
-@if (Model.RecentWorkLogs != null && Model.RecentWorkLogs.Any())
+@if (Model.RecentWorkLogs.Any())
 {
     <div class="row mt-4">
         <div class="col-md-12">
@@ -239,4 +247,8 @@
             </table>
         </div>
     </div>
+}
+else
+{
+    <div class="text-muted">No data available</div>
 }


### PR DESCRIPTION
## Summary
- Ensure `UserDashboardController` initializes dashboard collections to empty lists
- Display empty-state messages in the dashboard when projects, project reports, or work logs are absent

## Testing
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68949c00b114832b89572642ab1052fb