### PR TITLE
Add reporting exports to user dashboard

### DIFF
--- a/ProjectTracker.Service/Services/Implementations/ReportingService.cs
+++ b/ProjectTracker.Service/Services/Implementations/ReportingService.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using ClosedXML.Excel;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+using ProjectTracker.Service.DTOs;
+using ProjectTracker.Service.Enums;
+using ProjectTracker.Service.Services.Interfaces;
+
+namespace ProjectTracker.Service.Services.Implementations
+{
+    public class ReportingService : IReportingService
+    {
+        private readonly IWorkLogService _workLogService;
+        private readonly IUserDashboardService _dashboardService;
+
+        public ReportingService(IWorkLogService workLogService, IUserDashboardService dashboardService)
+        {
+            _workLogService = workLogService;
+            _dashboardService = dashboardService;
+        }
+
+        public async Task<byte[]> ExportWorkLogsAsync(int userId, ExportFormat format)
+        {
+            var workLogs = await _workLogService.GetWorkLogsByUserIdAsync(userId);
+            if (format == ExportFormat.Excel)
+                return ExportWorkLogsToExcel(workLogs);
+            if (format == ExportFormat.Pdf)
+                return ExportWorkLogsToPdf(workLogs);
+            return Array.Empty<byte>();
+        }
+
+        public async Task<byte[]> ExportActivityAsync(int userId, ExportFormat format)
+        {
+            var projects = await _dashboardService.GetUserProjectsAsync(userId);
+            if (format == ExportFormat.Excel)
+                return ExportActivityToExcel(projects);
+            if (format == ExportFormat.Pdf)
+                return ExportActivityToPdf(projects);
+            return Array.Empty<byte>();
+        }
+
+        public async Task<byte[]> ExportPerformanceAsync(int userId, ExportFormat format)
+        {
+            var stats = await _dashboardService.GetDashboardStatsAsync(userId);
+            if (format == ExportFormat.Excel)
+                return ExportPerformanceToExcel(stats);
+            if (format == ExportFormat.Pdf)
+                return ExportPerformanceToPdf(stats);
+            return Array.Empty<byte>();
+        }
+
+        private byte[] ExportWorkLogsToExcel(IEnumerable<WorkLogDto> logs)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("WorkLogs");
+            ws.Cell(1, 1).Value = "Date";
+            ws.Cell(1, 2).Value = "Project";
+            ws.Cell(1, 3).Value = "Hours";
+            ws.Cell(1, 4).Value = "Cost";
+
+            var row = 2;
+            foreach (var log in logs)
+            {
+                ws.Cell(row, 1).Value = log.WorkDate;
+                ws.Cell(row, 2).Value = log.ProjectName;
+                ws.Cell(row, 3).Value = log.HoursSpent;
+                ws.Cell(row, 4).Value = log.Cost;
+                row++;
+            }
+
+            using var ms = new MemoryStream();
+            wb.SaveAs(ms);
+            return ms.ToArray();
+        }
+
+        private byte[] ExportWorkLogsToPdf(IEnumerable<WorkLogDto> logs)
+        {
+            var document = Document.Create(container =>
+            {
+                container.Page(page =>
+                {
+                    page.Margin(20);
+                    page.Content().Table(table =>
+                    {
+                        table.ColumnsDefinition(c =>
+                        {
+                            c.RelativeColumn();
+                            c.RelativeColumn();
+                            c.RelativeColumn();
+                            c.RelativeColumn();
+                        });
+
+                        table.Header(header =>
+                        {
+                            header.Cell().Text("Date");
+                            header.Cell().Text("Project");
+                            header.Cell().Text("Hours");
+                            header.Cell().Text("Cost");
+                        });
+
+                        foreach (var log in logs)
+                        {
+                            table.Cell().Text(log.WorkDate.ToShortDateString());
+                            table.Cell().Text(log.ProjectName);
+                            table.Cell().Text(log.HoursSpent.ToString());
+                            table.Cell().Text(log.Cost.ToString());
+                        }
+                    });
+                });
+            });
+
+            return document.GeneratePdf();
+        }
+
+        private byte[] ExportActivityToExcel(IEnumerable<ProjectDto> projects)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Activity");
+            ws.Cell(1, 1).Value = "Project";
+            ws.Cell(1, 2).Value = "Start";
+            ws.Cell(1, 3).Value = "End";
+            ws.Cell(1, 4).Value = "Status";
+            var row = 2;
+            foreach (var p in projects)
+            {
+                ws.Cell(row, 1).Value = p.Name;
+                ws.Cell(row, 2).Value = p.StartDate;
+                ws.Cell(row, 3).Value = p.EndDate;
+                ws.Cell(row, 4).Value = p.Status.ToString();
+                row++;
+            }
+            using var ms = new MemoryStream();
+            wb.SaveAs(ms);
+            return ms.ToArray();
+        }
+
+        private byte[] ExportActivityToPdf(IEnumerable<ProjectDto> projects)
+        {
+            var document = Document.Create(container =>
+            {
+                container.Page(page =>
+                {
+                    page.Margin(20);
+                    page.Content().Table(table =>
+                    {
+                        table.ColumnsDefinition(c =>
+                        {
+                            c.RelativeColumn();
+                            c.RelativeColumn();
+                            c.RelativeColumn();
+                            c.RelativeColumn();
+                        });
+
+                        table.Header(header =>
+                        {
+                            header.Cell().Text("Project");
+                            header.Cell().Text("Start");
+                            header.Cell().Text("End");
+                            header.Cell().Text("Status");
+                        });
+
+                        foreach (var p in projects)
+                        {
+                            table.Cell().Text(p.Name);
+                            table.Cell().Text(p.StartDate.ToShortDateString());
+                            table.Cell().Text(p.EndDate?.ToShortDateString() ?? string.Empty);
+                            table.Cell().Text(p.Status.ToString());
+                        }
+                    });
+                });
+            });
+            return document.GeneratePdf();
+        }
+
+        private byte[] ExportPerformanceToExcel(DashboardStatsDto stats)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Performance");
+            ws.Cell(1, 1).Value = "Metric";
+            ws.Cell(1, 2).Value = "Value";
+            var data = new Dictionary<string, object>
+            {
+                {"Total Projects", stats.TotalProjects},
+                {"Active Projects", stats.ActiveProjects},
+                {"Completed Projects", stats.CompletedProjects},
+                {"Total Hours This Month", stats.TotalHoursThisMonth},
+                {"Total Hours This Week", stats.TotalHoursThisWeek},
+                {"Total Work Logs", stats.TotalWorkLogs}
+            };
+            var row = 2;
+            foreach (var item in data)
+            {
+                ws.Cell(row, 1).Value = item.Key;
+                ws.Cell(row, 2).Value = item.Value;
+                row++;
+            }
+            using var ms = new MemoryStream();
+            wb.SaveAs(ms);
+            return ms.ToArray();
+        }
+
+        private byte[] ExportPerformanceToPdf(DashboardStatsDto stats)
+        {
+            var data = new Dictionary<string, string>
+            {
+                {"Total Projects", stats.TotalProjects.ToString()},
+                {"Active Projects", stats.ActiveProjects.ToString()},
+                {"Completed Projects", stats.CompletedProjects.ToString()},
+                {"Total Hours This Month", stats.TotalHoursThisMonth.ToString()},
+                {"Total Hours This Week", stats.TotalHoursThisWeek.ToString()},
+                {"Total Work Logs", stats.TotalWorkLogs.ToString()}
+            };
+
+            var document = Document.Create(container =>
+            {
+                container.Page(page =>
+                {
+                    page.Margin(20);
+                    page.Content().Table(table =>
+                    {
+                        table.ColumnsDefinition(c =>
+                        {
+                            c.RelativeColumn();
+                            c.RelativeColumn();
+                        });
+
+                        table.Header(header =>
+                        {
+                            header.Cell().Text("Metric");
+                            header.Cell().Text("Value");
+                        });
+
+                        foreach (var item in data)
+                        {
+                            table.Cell().Text(item.Key);
+                            table.Cell().Text(item.Value);
+                        }
+                    });
+                });
+            });
+            return document.GeneratePdf();
+        }
+    }
+}

--- a/ProjectTracker.Service/Services/Interfaces/IReportingService.cs
+++ b/ProjectTracker.Service/Services/Interfaces/IReportingService.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+using ProjectTracker.Service.Enums;
+
+namespace ProjectTracker.Service.Services.Interfaces
+{
+    public interface IReportingService
+    {
+        Task<byte[]> ExportWorkLogsAsync(int userId, ExportFormat format);
+        Task<byte[]> ExportActivityAsync(int userId, ExportFormat format);
+        Task<byte[]> ExportPerformanceAsync(int userId, ExportFormat format);
+    }
+}

--- a/ProjectTracker.Web/Controllers/UserDashboardController.cs
+++ b/ProjectTracker.Web/Controllers/UserDashboardController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Authorization;
 using ProjectTracker.Service.Services.Interfaces;
 using ProjectTracker.Service.DTOs;
+using ProjectTracker.Service.Enums;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using System.Linq;
@@ -12,10 +13,12 @@ namespace ProjectTracker.Web.Controllers
     public class UserDashboardController : Controller
     {
         private readonly IUserDashboardService _userDashboardService;
+        private readonly IReportingService _reportingService;
 
-        public UserDashboardController(IUserDashboardService userDashboardService)
+        public UserDashboardController(IUserDashboardService userDashboardService, IReportingService reportingService)
         {
             _userDashboardService = userDashboardService;
+            _reportingService = reportingService;
         }
 
         public async Task<IActionResult> Index()
@@ -40,6 +43,51 @@ namespace ProjectTracker.Web.Controllers
                 .ToList();
 
             return View(dashboardData);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> ExportWorkLogs(string format)
+        {
+            var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier);
+            if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out int userId))
+                return RedirectToAction("Login", "Account");
+
+            var exportFormat = Enum.TryParse<ExportFormat>(format, true, out var fmt) ? fmt : ExportFormat.Excel;
+            var bytes = await _reportingService.ExportWorkLogsAsync(userId, exportFormat);
+            var contentType = fmt == ExportFormat.Excel ?
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" : "application/pdf";
+            var fileName = fmt == ExportFormat.Excel ? "worklogs.xlsx" : "worklogs.pdf";
+            return File(bytes, contentType, fileName);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> ExportActivity(string format)
+        {
+            var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier);
+            if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out int userId))
+                return RedirectToAction("Login", "Account");
+
+            var exportFormat = Enum.TryParse<ExportFormat>(format, true, out var fmt) ? fmt : ExportFormat.Excel;
+            var bytes = await _reportingService.ExportActivityAsync(userId, exportFormat);
+            var contentType = fmt == ExportFormat.Excel ?
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" : "application/pdf";
+            var fileName = fmt == ExportFormat.Excel ? "activity.xlsx" : "activity.pdf";
+            return File(bytes, contentType, fileName);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> ExportPerformance(string format)
+        {
+            var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier);
+            if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out int userId))
+                return RedirectToAction("Login", "Account");
+
+            var exportFormat = Enum.TryParse<ExportFormat>(format, true, out var fmt) ? fmt : ExportFormat.Excel;
+            var bytes = await _reportingService.ExportPerformanceAsync(userId, exportFormat);
+            var contentType = fmt == ExportFormat.Excel ?
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" : "application/pdf";
+            var fileName = fmt == ExportFormat.Excel ? "performance.xlsx" : "performance.pdf";
+            return File(bytes, contentType, fileName);
         }
     }
 }

--- a/ProjectTracker.Web/Program.cs
+++ b/ProjectTracker.Web/Program.cs
@@ -133,6 +133,7 @@ builder.Services.AddScoped<IAuthorizationHandler, WorkLogAuthorizationHandler>()
 
 // Add before builder.Build()
 builder.Services.AddScoped<IUserDashboardService, UserDashboardService>(); // if you have this service
+builder.Services.AddScoped<IReportingService, ReportingService>();
 
 builder.Services.AddMediatR(typeof(EmployeeUpdatedEventHandler).Assembly);
 builder.Services.AddScoped<IUserProjectService, UserProjectService>();

--- a/ProjectTracker.Web/Views/UserDashboard/Index.cshtml
+++ b/ProjectTracker.Web/Views/UserDashboard/Index.cshtml
@@ -7,6 +7,39 @@
 
 <h1>@L["ControlPanel"]</h1>
 
+<div class="mb-3">
+    <form asp-action="ExportWorkLogs" method="post" class="d-inline">
+        <input type="hidden" name="format" value="Excel" />
+        <button type="submit" class="btn btn-success btn-sm">Export Work Logs to Excel</button>
+    </form>
+    <form asp-action="ExportWorkLogs" method="post" class="d-inline">
+        <input type="hidden" name="format" value="Pdf" />
+        <button type="submit" class="btn btn-danger btn-sm">Export Work Logs to PDF</button>
+    </form>
+</div>
+
+<div class="mb-3">
+    <form asp-action="ExportActivity" method="post" class="d-inline">
+        <input type="hidden" name="format" value="Excel" />
+        <button type="submit" class="btn btn-success btn-sm">Export Activity to Excel</button>
+    </form>
+    <form asp-action="ExportActivity" method="post" class="d-inline">
+        <input type="hidden" name="format" value="Pdf" />
+        <button type="submit" class="btn btn-danger btn-sm">Export Activity to PDF</button>
+    </form>
+</div>
+
+<div class="mb-3">
+    <form asp-action="ExportPerformance" method="post" class="d-inline">
+        <input type="hidden" name="format" value="Excel" />
+        <button type="submit" class="btn btn-success btn-sm">Export Performance to Excel</button>
+    </form>
+    <form asp-action="ExportPerformance" method="post" class="d-inline">
+        <input type="hidden" name="format" value="Pdf" />
+        <button type="submit" class="btn btn-danger btn-sm">Export Performance to PDF</button>
+    </form>
+</div>
+
 <div class="row mb-4">
     <div class="col-md-4">
         <div class="card shadow-sm">


### PR DESCRIPTION
## Summary
- add `ReportingService` to export work logs, project activity, and performance data to Excel or PDF
- expose export endpoints in `UserDashboardController` and wire up buttons in `Index.cshtml`
- register reporting service in `Program.cs`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68949c07c960832b9765d447899dd2dd