### PR TITLE
Add recent equipment and maintenance activity to user dashboard

### DIFF
--- a/ProjectTracker.Service/DTOs/DashboardDto.cs
+++ b/ProjectTracker.Service/DTOs/DashboardDto.cs
@@ -9,6 +9,8 @@ namespace ProjectTracker.Service.DTOs
         public List<string> UserRoles { get; set; }
         public DashboardStatsDto Stats { get; set; }
         public List<WorkLogDto> RecentWorkLogs { get; set; }
+        public List<MaintenanceLogDto> RecentMaintenanceLogs { get; set; }
+        public List<EquipmentActionDto> RecentEquipmentActions { get; set; }
         public List<ProjectDto> ActiveProjects { get; set; }
         public List<ProjectReportDto> ProjectReports { get; set; }
     }

--- a/ProjectTracker.Service/DTOs/EquipmentActionDto.cs
+++ b/ProjectTracker.Service/DTOs/EquipmentActionDto.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace ProjectTracker.Service.DTOs
+{
+    public class EquipmentActionDto
+    {
+        public DateTime Date { get; set; }
+        public string Equipment { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+    }
+}

--- a/ProjectTracker.Service/DTOs/MaintenanceLogDto.cs
+++ b/ProjectTracker.Service/DTOs/MaintenanceLogDto.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace ProjectTracker.Service.DTOs
+{
+    public class MaintenanceLogDto
+    {
+        public DateTime Date { get; set; }
+        public string Equipment { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+    }
+}

--- a/ProjectTracker.Service/Services/Interfaces/IUserDashboardService.cs
+++ b/ProjectTracker.Service/Services/Interfaces/IUserDashboardService.cs
@@ -9,6 +9,8 @@ namespace ProjectTracker.Service.Services.Interfaces
         Task<DashboardDto> GetDashboardDataAsync(int userId);
         Task<DashboardStatsDto> GetDashboardStatsAsync(int userId);
         Task<IEnumerable<WorkLogDto>> GetRecentWorkLogsAsync(int userId, int count = 5);
+        Task<IEnumerable<MaintenanceLogDto>> GetRecentMaintenanceLogsAsync(int userId, int count = 5);
+        Task<IEnumerable<EquipmentActionDto>> GetRecentEquipmentActionsAsync(int userId, int count = 5);
         Task<IEnumerable<ProjectDto>> GetUserProjectsAsync(int userId);
         Task<IEnumerable<ProjectReportDto>> GetProjectReportsAsync(int userId);
     }

--- a/ProjectTracker.Web/Views/UserDashboard/Index.cshtml
+++ b/ProjectTracker.Web/Views/UserDashboard/Index.cshtml
@@ -219,20 +219,52 @@
             <table class="table">
                 <thead>
                     <tr>
-                        <th>@L["Project"]</th>
-                        <th>@L["Description"]</th>
                         <th>@L["Date"]</th>
+                        <th>@L["Title"]</th>
+                        <th>@L["Project"]</th>
                         <th>@L["Duration"]</th>
+                        <th>@L["Status"]</th>
                     </tr>
                 </thead>
                 <tbody>
                     @foreach (var workLog in Model.RecentWorkLogs)
                     {
                         <tr>
-                            <td>@workLog.ProjectName</td>
-                            <td>@workLog.Description</td>
                             <td>@workLog.WorkDate.ToString("dd.MM.yyyy")</td>
-                            <td>@workLog.HoursSpent @L["Hours"]</td>
+                            <td>@workLog.Title</td>
+                            <td>@workLog.ProjectName</td>
+                            <td>@workLog.HoursSpent</td>
+                            <td>@L["Logged"]</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+}
+
+@if (Model.RecentEquipmentActions != null && Model.RecentEquipmentActions.Any())
+{
+    <div class="row mt-4">
+        <div class="col-md-12">
+            <h3>@L["RecentEquipmentActions"]</h3>
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>@L["Date"]</th>
+                        <th>@L["Equipment"]</th>
+                        <th>@L["Description"]</th>
+                        <th>@L["Status"]</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var action in Model.RecentEquipmentActions)
+                    {
+                        <tr>
+                            <td>@action.Date.ToString("dd.MM.yyyy")</td>
+                            <td>@action.Equipment</td>
+                            <td>@action.Description</td>
+                            <td>@action.Status</td>
                         </tr>
                     }
                 </tbody>


### PR DESCRIPTION
## Summary
- show recent work logs and equipment actions on dashboard
- expose methods to fetch recent maintenance logs and equipment actions
- wire up DTOs for equipment and maintenance entries

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68949c14e550832b9345c18ca8db52d5